### PR TITLE
Added fuzzy searching for build orders

### DIFF
--- a/aoe2/aoe2_settings.py
+++ b/aoe2/aoe2_settings.py
@@ -17,7 +17,7 @@ class AoE2ConfigurationLayout(SettingsSubclass):
         self.selected_build_order_color: list = [230, 159, 0]  # color for selected build order
         self.hovering_build_order_color: list = [204, 102, 0]  # color for build order hovered by mouse
         self.selected_username_color: list = [86, 180, 233]  # color for selected username
-        self.bo_list_max_count: int = 15  # maximum count of valid build orders in the selection list
+        self.bo_list_max_count: int = 8  # maximum count of valid build orders in the selection list
 
 
 class AoE2BuildOrderLayout(SettingsSubclass):

--- a/common/rts_overlay.py
+++ b/common/rts_overlay.py
@@ -788,13 +788,13 @@ class RTSGameOverlay(QMainWindow):
         key_condition   dictionary with the keys to look for and their value (to consider as valid), None to skip it
         """
         self.valid_build_orders = []  # reset the list
-        build_order_search_string = self.build_order_search.text().lower()
+        build_order_search_string = self.build_order_search.text()
         if build_order_search_string == '':  # no text added
             return
 
         self.valid_build_orders = [match[0] for match in process.extractBests(
             build_order_search_string,
-            [build_order["name"].lower() for build_order in self.build_orders],
+            [build_order["name"] for build_order in self.build_orders],
             score_cutoff=50,
             limit=self.settings.layout.configuration.bo_list_max_count
         )]

--- a/common/rts_overlay.py
+++ b/common/rts_overlay.py
@@ -792,6 +792,7 @@ class RTSGameOverlay(QMainWindow):
         if build_order_search_string == '':  # no text added
             return
 
+        # Do a fuzzy search for matching build orders
         self.valid_build_orders = [match[0] for match in process.extractBests(
             build_order_search_string,
             [build_order["name"] for build_order in self.build_orders],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 pynput==1.7.6
 PyQt5==5.15.7
 requests==2.28.1
+thefuzz==0.19.0
+python-Levenshtein==0.12.2


### PR DESCRIPTION
I introduced the overlay to some friends who requested this feature. This allows the user to find a build order even if there are some typos in the search bar. It does add a dependency (thefuzz) but it's only a 56KB library along with python-Levenshtein (< 1 KB) for a significant speedup in search times. 