### PR TITLE
Improve the BO helper & add AoE timing feature

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,12 @@
 ## [1.9.1] - in progress
-* Switch to build order panel when opening the BO writer panel.
-* Button to display the BO being built.
 * Option to keep the BO writer and hotkeys configuration always on top.
-* Add BO step using resources from previous step if available.
+* Add hotkeys to only start OR stop the BO timing run.
+* BO writer panel
+    * Switch to build order panel when opening the BO writer panel.
+    * Button to display the BO being built.
+    * Add BO step using resources from previous step if available.
+    * Focus on the end of the BO when formatting or adding a step.
+    * Check if BO is valid for timing and display it.
 * AoE2
     * Do not copy sample BOs at creation (outdated BOs).
     * Build order timing evaluation function.

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,9 @@
 * Add BO step using resources from previous step if available.
 * AoE2
     * Do not copy sample BOs at creation (outdated BOs).
+    * Build order timing evaluation function.
+* AoE4
+    * Build order timing evaluation function.
 
 ## [1.9.0] - 2024.02.11
 * SC2

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,8 @@
 ## [1.9.1] - in progress
 * Switch to build order panel when opening the BO writer panel.
 * Button to display the BO being built.
+* Option to keep the BO writer and hotkeys configuration always on top.
+* Add BO step using resources from previous step if available.
 * AoE2
     * Do not copy sample BOs at creation (outdated BOs).
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-## [1.9.1] - in progress
+## [1.9.1] - 2024.03.17
 * Option to keep the BO writer and hotkeys configuration always on top.
 * Add hotkeys to only start OR stop the BO timing run.
 * BO writer panel

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,9 +9,10 @@
     * Check if BO is valid for timing and display it.
 * AoE2
     * Do not copy sample BOs at creation (outdated BOs).
+* AoE2 & AoE4
     * Build order timing evaluation function.
-* AoE4
-    * Build order timing evaluation function.
+    * Build order timing feature available (like SC2).
+    * Remove tooltip feature (generating issues with BO panel).
 
 ## [1.9.0] - 2024.02.11
 * SC2

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+## [1.9.1] - in progress
+* Switch to build order panel when opening the BO writer panel.
+
 ## [1.9.0] - 2024.02.11
 * SC2
     * Timer feature added.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 ## [1.9.1] - in progress
 * Switch to build order panel when opening the BO writer panel.
+* Button to display the BO being built.
+* AoE2
+    * Do not copy sample BOs at creation (outdated BOs).
 
 ## [1.9.0] - 2024.02.11
 * SC2

--- a/aoe2/aoe2_build_order.py
+++ b/aoe2/aoe2_build_order.py
@@ -3,17 +3,17 @@ from common.build_order_tools import build_order_time_to_str
 
 
 def check_valid_aoe2_build_order(data: dict, bo_name_msg: bool = False) -> (bool, str):
-    """Check if a build order is valid for AoE2
+    """Check if a build order is valid for AoE2.
 
     Parameters
     ----------
-    data           data of the build order JSON file
-    bo_name_msg    True to add the build order name in the error message
+    data           Data of the build order JSON file.
+    bo_name_msg    True to add the build order name in the error message.
 
     Returns
     -------
-    True if valid build order, False otherwise
-    string indicating the error (empty if no error)
+    True if valid build order, False otherwise.
+    String indicating the error (empty if no error).
     """
     bo_name_str: str = ''
     try:
@@ -112,15 +112,16 @@ def check_valid_aoe2_build_order(data: dict, bo_name_msg: bool = False) -> (bool
 
 
 def aoe2_build_order_sorting(elem: dict) -> int:
-    """Sorting key used to order the build orders: civilizations set as 'Any'/'any'/'Generic' (or not specified) appear at the end.
+    """Sorting key used to order the build orders:
+       civilizations set as 'Any'/'any'/'Generic' (or not specified) appear at the end.
 
     Parameters
     ----------
-    elem    build order data to analyze
+    elem    Build order data to analyze.
 
     Returns
     -------
-    key value for sorting
+    Key value for sorting.
     """
     return 1 if (('civilization' not in elem) or (elem['civilization'] in ['any', 'Any', 'Generic'])) else 0
 
@@ -130,7 +131,7 @@ def get_aoe2_build_order_step(build_order_data: dict = None) -> dict:
 
     Parameters
     ----------
-    build_order_data    data with the build order
+    build_order_data    Data with the build order.
 
     Returns
     -------

--- a/aoe2/aoe2_build_order.py
+++ b/aoe2/aoe2_build_order.py
@@ -1,5 +1,5 @@
 from aoe2.aoe2_civ_icon import aoe2_civilization_icon
-from common.build_order_tools import is_valid_resource, build_order_time_to_str
+from common.build_order_tools import build_order_time_to_str
 
 
 def check_valid_aoe2_build_order(data: dict, bo_name_msg: bool = False) -> (bool, str):
@@ -80,20 +80,20 @@ def check_valid_aoe2_build_order(data: dict, bo_name_msg: bool = False) -> (bool
             if 'stone' not in resources:
                 return False, bo_name_str + f'{step_str} is missing the \'stone\' field in \'resources\'.'
 
-            if not is_valid_resource(resources['wood']):
+            if not isinstance(resources['wood'], int):
                 return False, bo_name_str + f'{step_str} has an invalid \'wood\' resource ({resources["wood"]}).'
 
-            if not is_valid_resource(resources['food']):
+            if not isinstance(resources['food'], int):
                 return False, bo_name_str + f'{step_str} has an invalid \'food\' resource ({resources["food"]}).'
 
-            if not is_valid_resource(resources['gold']):
+            if not isinstance(resources['gold'], int):
                 return False, bo_name_str + f'{step_str} has an invalid \'gold\' resource ({resources["gold"]}).'
 
-            if not is_valid_resource(resources['stone']):
+            if not isinstance(resources['stone'], int):
                 return False, bo_name_str + f'{step_str} has an invalid \'stone\' resource ({resources["stone"]}).'
 
             # optional builder count
-            if ('builder' in resources) and (not is_valid_resource(resources['builder'])):
+            if ('builder' in resources) and (not isinstance(resources['builder'], int)):
                 return False, bo_name_str + f'{step_str} has an invalid \'builder\' resource.'
 
             # notes

--- a/aoe2/aoe2_build_order.py
+++ b/aoe2/aoe2_build_order.py
@@ -186,12 +186,13 @@ def get_aoe2_build_order_template() -> dict:
     }
 
 
-def evaluate_aoe2_build_order_timing(data: dict):
+def evaluate_aoe2_build_order_timing(data: dict, time_offset: int = 0):
     """Evaluate the time indications for an AoE2 build order.
 
     Parameters
     ----------
-    data    Data of the build order (will be updated).
+    data           Data of the build order (will be updated).
+    time_offset    Offset to add on the time outputs [sec].
     """
     # creation times [sec]
     villager_time: int = 25
@@ -203,4 +204,4 @@ def evaluate_aoe2_build_order_timing(data: dict):
     build_order_data = data['build_order']
     for step in build_order_data:
         villager_count = step['villager_count']
-        step['time'] = build_order_time_to_str(villager_time * villager_count)
+        step['time'] = build_order_time_to_str(villager_time * villager_count + time_offset)

--- a/aoe2/aoe2_build_order.py
+++ b/aoe2/aoe2_build_order.py
@@ -125,27 +125,49 @@ def aoe2_build_order_sorting(elem: dict) -> int:
     return 1 if (('civilization' not in elem) or (elem['civilization'] in ['any', 'Any', 'Generic'])) else 0
 
 
-def get_aoe2_build_order_step() -> dict:
+def get_aoe2_build_order_step(build_order_data: dict = None) -> dict:
     """Get one step of the AoE2 build order (template).
+
+    Parameters
+    ----------
+    build_order_data    data with the build order
 
     Returns
     -------
     Dictionary with the build order step template.
     """
-    return {
-        'villager_count': 0,
-        'age': 1,
-        'resources': {
-            'wood': 0,
-            'food': 0,
-            'gold': 0,
-            'stone': 0
-        },
-        'notes': [
-            'Note 1.',
-            'Note 2.'
-        ]
-    }
+    if build_order_data is not None:
+        assert isinstance(build_order_data, list) and len(build_order_data) >= 1
+        data = build_order_data[-1]  # last step data
+        return {
+            'villager_count': data['villager_count'] if ('villager_count' in data) else 0,
+            'age': data['age'] if ('age' in data) else 1,
+            'resources': data['resources'] if ('resources' in data) else {
+                'wood': 0,
+                'food': 0,
+                'gold': 0,
+                'stone': 0
+            },
+            'notes': [
+                'Note 1.',
+                'Note 2.'
+            ]
+        }
+    else:
+        return {
+            'villager_count': 0,
+            'age': 1,
+            'resources': {
+                'wood': 0,
+                'food': 0,
+                'gold': 0,
+                'stone': 0
+            },
+            'notes': [
+                'Note 1.',
+                'Note 2.'
+            ]
+        }
 
 
 def get_aoe2_build_order_template() -> dict:

--- a/aoe2/aoe2_build_order.py
+++ b/aoe2/aoe2_build_order.py
@@ -389,11 +389,11 @@ def evaluate_aoe2_build_order_timing(data: dict, time_offset: int = 0):
 
     # TC technologies to research
     tc_technologies = {
-        'loom': {'researched': False, 'researching': False, 'image': 'town_center/LoomDE.png'},
-        'wheelbarrow': {'researched': False, 'researching': False, 'image': 'town_center/WheelbarrowDE.png'},
-        'handcart': {'researched': False, 'researching': False, 'image': 'town_center/HandcartDE.png'},
-        'town_watch': {'researched': False, 'researching': False, 'image': 'town_center/TownWatchDE.png'},
-        'town_patrol': {'researched': False, 'researching': False, 'image': 'town_center/TownPatrolDE.png'}
+        'loom': {'researched': False, 'image': 'town_center/LoomDE.png'},
+        'wheelbarrow': {'researched': False, 'image': 'town_center/WheelbarrowDE.png'},
+        'handcart': {'researched': False, 'image': 'town_center/HandcartDE.png'},
+        'town_watch': {'researched': False, 'image': 'town_center/TownWatchDE.png'},
+        'town_patrol': {'researched': False, 'image': 'town_center/TownPatrolDE.png'}
     }
 
     last_time_sec: float = float(time_offset)  # time of the last step
@@ -428,7 +428,7 @@ def evaluate_aoe2_build_order_timing(data: dict, time_offset: int = 0):
         if next_age == current_age + 1:  # researching next age up
             step_total_time += get_research_age_up_time(civilization_flags, current_age)
 
-        # check for loom/wheelbarrow/handcart in notes
+        # check for TC technologies in notes
         for note in step['notes']:
             for technology_name, technology_data in tc_technologies.items():
                 if (not technology_data['researched']) and (('@' + technology_data['image'] + '@') in note):

--- a/aoe2/aoe2_build_order.py
+++ b/aoe2/aoe2_build_order.py
@@ -1,5 +1,5 @@
 from aoe2.aoe2_civ_icon import aoe2_civilization_icon
-from common.build_order_tools import is_valid_resource
+from common.build_order_tools import is_valid_resource, build_order_time_to_str
 
 
 def check_valid_aoe2_build_order(data: dict, bo_name_msg: bool = False) -> (bool, str):
@@ -184,3 +184,23 @@ def get_aoe2_build_order_template() -> dict:
         'source': 'Source',
         'build_order': [get_aoe2_build_order_step()]
     }
+
+
+def evaluate_aoe2_build_order_timing(data: dict):
+    """Evaluate the time indications for an AoE2 build order.
+
+    Parameters
+    ----------
+    data    Data of the build order (will be updated).
+    """
+    # creation times [sec]
+    villager_time: int = 25
+
+    if 'build_order' not in data:
+        print('The \'build_order\' field is missing from data when evaluating the timing.')
+        return
+
+    build_order_data = data['build_order']
+    for step in build_order_data:
+        villager_count = step['villager_count']
+        step['time'] = build_order_time_to_str(villager_time * villager_count)

--- a/aoe2/aoe2_build_order.py
+++ b/aoe2/aoe2_build_order.py
@@ -403,8 +403,9 @@ def evaluate_aoe2_build_order_timing(data: dict, time_offset: int = 0):
         return
 
     build_order_data = data['build_order']
+    step_count = len(build_order_data)
 
-    for step in build_order_data:  # loop on all the build order steps
+    for step_id, step in enumerate(build_order_data):  # loop on all the build order steps
 
         step_total_time: float = 0.0  # total time for this step
 
@@ -442,3 +443,8 @@ def evaluate_aoe2_build_order_timing(data: dict, time_offset: int = 0):
 
         # update build order with time
         step['time'] = build_order_time_to_str(int(round(last_time_sec)))
+
+        # special case for last step (add 1 sec to avoid displaying both at the same time)
+        if (step_id == step_count - 1) and (step_count >= 2) and (
+                step['time'] == build_order_data[step_id - 1]['time']):
+            step['time'] = build_order_time_to_str(int(round(last_time_sec + 1.0)))

--- a/aoe2/aoe2_game_overlay.py
+++ b/aoe2/aoe2_game_overlay.py
@@ -1,19 +1,19 @@
 # AoE2 game overlay
 import os
-import shutil
 
 from PyQt5.QtWidgets import QApplication, QComboBox
 from PyQt5.QtGui import QIcon, QFont
 from PyQt5.QtCore import QSize
 
-from common.useful_tools import widget_x_end, widget_y_end, popup_message
+from common.useful_tools import widget_x_end, widget_y_end
 from common.rts_overlay import RTSGameOverlay, scale_list_int, PanelID
-from common.build_order_tools import get_total_on_resource, get_build_orders
+from common.build_order_tools import get_total_on_resource
 from common.build_order_window import BuildOrderWindow
 
 from aoe2.aoe2_settings import AoE2OverlaySettings
 from aoe2.aoe2_build_order import check_valid_aoe2_build_order, aoe2_build_order_sorting
-from aoe2.aoe2_build_order import get_aoe2_build_order_step, get_aoe2_build_order_template
+from aoe2.aoe2_build_order import get_aoe2_build_order_step, get_aoe2_build_order_template, \
+    evaluate_aoe2_build_order_timing
 from aoe2.aoe2_civ_icon import aoe2_civilization_icon, get_aoe2_faction_selection
 
 
@@ -33,7 +33,8 @@ class AoE2GameOverlay(RTSGameOverlay):
                          check_valid_build_order=check_valid_aoe2_build_order,
                          get_build_order_step=get_aoe2_build_order_step,
                          get_build_order_template=get_aoe2_build_order_template,
-                         get_faction_selection=get_aoe2_faction_selection)
+                         get_faction_selection=get_aoe2_faction_selection,
+                         evaluate_build_order_timing=evaluate_aoe2_build_order_timing)
 
         # build order instructions
         self.build_order_instructions = \

--- a/aoe2/aoe2_game_overlay.py
+++ b/aoe2/aoe2_game_overlay.py
@@ -282,15 +282,10 @@ class AoE2GameOverlay(RTSGameOverlay):
 
     def update_build_order(self):
         """Update the build order panel"""
+        super().update_build_order()
 
-        # clear the elements (also hide them)
-        self.build_order_resources.clear()
-        self.build_order_notes.clear()
-
-        if self.selected_build_order is None:  # no build order selected
-            self.build_order_notes.add_row_from_picture_line(parent=self, line='No build order selected.')
-
-        else:  # valid build order selected
+        # valid build order selected
+        if (self.selected_build_order is not None) and ('build_order' in self.selected_build_order):
             selected_build_order_content = self.selected_build_order['build_order']
 
             # select current step

--- a/aoe2/aoe2_game_overlay.py
+++ b/aoe2/aoe2_game_overlay.py
@@ -408,6 +408,8 @@ class AoE2GameOverlay(RTSGameOverlay):
 
     def open_panel_add_build_order(self):
         """Open/close the panel to add a build order"""
+        super().open_panel_add_build_order()
+
         if (self.panel_add_build_order is not None) and self.panel_add_build_order.isVisible():  # close panel
             self.panel_add_build_order.close()
             self.panel_add_build_order = None

--- a/aoe2/aoe2_game_overlay.py
+++ b/aoe2/aoe2_game_overlay.py
@@ -7,7 +7,6 @@ from PyQt5.QtCore import QSize
 
 from common.useful_tools import widget_x_end, widget_y_end
 from common.rts_overlay import RTSGameOverlay, scale_list_int, PanelID
-from common.build_order_tools import get_total_on_resource
 from common.build_order_window import BuildOrderWindow
 
 from aoe2.aoe2_settings import AoE2OverlaySettings
@@ -58,8 +57,6 @@ class AoE2GameOverlay(RTSGameOverlay):
             '\n\nYou can find all your saved build orders as JSON files by clicking on \'Open build orders folder\'.' \
             '\nTo remove any build order, just delete the corresponding file and use \'reload settings\' ' \
             '(or relaunch the overlay).'
-
-        self.bo_tooltip_available = True  # activate tooltip feature in build order
 
         # civilization selection
         layout = self.settings.layout
@@ -279,12 +276,11 @@ class AoE2GameOverlay(RTSGameOverlay):
 
             # target resources
             target_resources = selected_step['resources']
-            target_wood = get_total_on_resource(target_resources['wood'])
-            target_food = get_total_on_resource(target_resources['food'])
-            target_gold = get_total_on_resource(target_resources['gold'])
-            target_stone = get_total_on_resource(target_resources['stone'])
-            target_builder = get_total_on_resource(target_resources['builder']) if (
-                    'builder' in target_resources) else -1
+            target_wood = target_resources['wood']
+            target_food = target_resources['food']
+            target_gold = target_resources['gold']
+            target_stone = target_resources['stone']
+            target_builder = target_resources['builder'] if ('builder' in target_resources) else -1
             target_villager = selected_step['villager_count']
 
             # space between the resources
@@ -313,11 +309,7 @@ class AoE2GameOverlay(RTSGameOverlay):
             if ('time' in selected_step) and (selected_step['time'] != ''):  # add time if indicated
                 resources_line += '@' + spacing + '@' + self.settings.images.time + '@' + selected_step['time']
 
-            # for dict type target_resources, create a tooltip to associate with the resource icon
-            mapping = {'wood': images.wood, 'food': images.food, 'gold': images.gold, 'stone': images.stone}
-            tooltip = dict((mapping[key], value) for (key, value) in target_resources.items() if type(value) is dict)
-            self.build_order_resources.add_row_from_picture_line(
-                parent=self, line=str(resources_line), tooltips=tooltip)
+            self.build_order_resources.add_row_from_picture_line(parent=self, line=str(resources_line))
 
             # line before notes
             self.build_order_notes.add_row_color(

--- a/aoe2/aoe2_game_overlay.py
+++ b/aoe2/aoe2_game_overlay.py
@@ -325,7 +325,8 @@ class AoE2GameOverlay(RTSGameOverlay):
                 resources_line += spacing + '@' + images.villager + '@ ' + str(target_villager)
             if 1 <= resource_step['age'] <= 4:
                 resources_line += spacing + '@' + self.get_age_image(resource_step['age'])
-            if ('time' in resource_step) and (resource_step['time'] != ''):  # add time if indicated
+            # add time if indicated
+            if layout.show_time_resource and ('time' in resource_step) and (resource_step['time'] != ''):
                 resources_line += '@' + spacing + '@' + self.settings.images.time + '@' + resource_step['time']
 
             self.build_order_resources.add_row_from_picture_line(parent=self, line=str(resources_line))

--- a/aoe2/aoe2_game_overlay.py
+++ b/aoe2/aoe2_game_overlay.py
@@ -81,25 +81,8 @@ class AoE2GameOverlay(RTSGameOverlay):
         self.civilization_select.setFont(QFont(layout.font_police, layout.font_size))
         self.civilization_select.adjustSize()
 
-        # initialize build orders if folder does not exist and copy the samples
-        self.sample_directory_build_orders = os.path.join(self.directory_main, 'build_orders', self.name_game)
-        if not os.path.isdir(self.directory_build_orders):
-            os.makedirs(self.directory_build_orders, exist_ok=True)  # create directory
-
-            # copy files
-            for file_name in os.listdir(self.sample_directory_build_orders):
-                source = os.path.join(self.sample_directory_build_orders, file_name)
-                destination = os.path.join(self.directory_build_orders, file_name)
-                if os.path.isfile(source):
-                    shutil.copy(source, destination)
-
-            # load build orders
-            self.build_orders = get_build_orders(self.directory_build_orders, self.check_valid_build_order,
-                                                 category_name=self.build_order_category_name)
-
-            # display popup message
-            popup_message('AoE2 build orders initialization',
-                          f'AoE2 sample build orders copied in {self.directory_build_orders}.')
+        # create build orders folder
+        os.makedirs(self.directory_build_orders, exist_ok=True)
 
         # sort build orders
         self.build_orders.sort(key=aoe2_build_order_sorting)

--- a/aoe2/aoe2_game_overlay.py
+++ b/aoe2/aoe2_game_overlay.py
@@ -8,6 +8,7 @@ from PyQt5.QtCore import QSize
 from common.useful_tools import widget_x_end, widget_y_end
 from common.rts_overlay import RTSGameOverlay, scale_list_int, PanelID
 from common.build_order_window import BuildOrderWindow
+from common.build_order_tools import get_build_order_timer_steps_display
 
 from aoe2.aoe2_settings import AoE2OverlaySettings
 from aoe2.aoe2_build_order import check_valid_aoe2_build_order, aoe2_build_order_sorting
@@ -33,7 +34,8 @@ class AoE2GameOverlay(RTSGameOverlay):
                          get_build_order_step=get_aoe2_build_order_step,
                          get_build_order_template=get_aoe2_build_order_template,
                          get_faction_selection=get_aoe2_faction_selection,
-                         evaluate_build_order_timing=evaluate_aoe2_build_order_timing)
+                         evaluate_build_order_timing=evaluate_aoe2_build_order_timing,
+                         build_order_timer_step_starting_flag=False)
 
         # build order instructions
         self.build_order_instructions = \
@@ -265,34 +267,51 @@ class AoE2GameOverlay(RTSGameOverlay):
         """Update the build order panel"""
         super().update_build_order()
 
+        layout = self.settings.layout
+        self.adapt_notes_to_columns = -1  # no column adaptation by default
+
         # valid build order selected
         if (self.selected_build_order is not None) and ('build_order' in self.selected_build_order):
-            selected_build_order_content = self.selected_build_order['build_order']
 
-            # select current step
-            assert 0 <= self.selected_build_order_step_id < self.selected_build_order_step_count
-            selected_step = selected_build_order_content[self.selected_build_order_step_id]
-            assert selected_step is not None
+            if self.build_order_timer['use_timer'] and self.build_order_timer['steps']:
+                # get steps to display
+                selected_steps_ids, selected_steps = get_build_order_timer_steps_display(
+                    self.build_order_timer['steps'], self.build_order_timer['steps_ids'])
+            else:
+                selected_build_order_content = self.selected_build_order['build_order']
+
+                # select current step
+                assert 0 <= self.selected_build_order_step_id < self.selected_build_order_step_count
+                selected_steps_ids = [0]
+                selected_steps = [selected_build_order_content[self.selected_build_order_step_id]]
+                assert selected_steps[0] is not None
+            assert (len(selected_steps) > 0) and (len(selected_steps_ids) > 0)
+
+            # space between the elements
+            spacing = ''
+            for i in range(layout.build_order.resource_spacing):
+                spacing += ' '
+
+            # display selected step
+            if self.build_order_timer['use_timer']:
+                self.update_build_order_time_label()
+            else:
+                self.update_build_order_step_label()
+
+            images = self.settings.images
+
+            # resource line
+            resource_step = selected_steps[selected_steps_ids[-1]]  # ID of the step to use to display the resources
+            resources_line = ''
 
             # target resources
-            target_resources = selected_step['resources']
+            target_resources = resource_step['resources']
             target_wood = target_resources['wood']
             target_food = target_resources['food']
             target_gold = target_resources['gold']
             target_stone = target_resources['stone']
             target_builder = target_resources['builder'] if ('builder' in target_resources) else -1
-            target_villager = selected_step['villager_count']
-
-            # space between the resources
-            spacing = ''
-            layout = self.settings.layout
-            for i in range(layout.build_order.resource_spacing):
-                spacing += ' '
-
-            # display selected step
-            self.update_build_order_step_label()
-
-            images = self.settings.images
+            target_villager = resource_step['villager_count']
 
             # line to display the target resources
             resources_line = images.wood + '@ ' + (str(target_wood) if (target_wood >= 0) else ' ')
@@ -304,10 +323,10 @@ class AoE2GameOverlay(RTSGameOverlay):
                 resources_line += spacing + '@' + images.builder + '@ ' + str(target_builder)
             if target_villager >= 0:
                 resources_line += spacing + '@' + images.villager + '@ ' + str(target_villager)
-            if 1 <= selected_step['age'] <= 4:
-                resources_line += spacing + '@' + self.get_age_image(selected_step['age'])
-            if ('time' in selected_step) and (selected_step['time'] != ''):  # add time if indicated
-                resources_line += '@' + spacing + '@' + self.settings.images.time + '@' + selected_step['time']
+            if 1 <= resource_step['age'] <= 4:
+                resources_line += spacing + '@' + self.get_age_image(resource_step['age'])
+            if ('time' in resource_step) and (resource_step['time'] != ''):  # add time if indicated
+                resources_line += '@' + spacing + '@' + self.settings.images.time + '@' + resource_step['time']
 
             self.build_order_resources.add_row_from_picture_line(parent=self, line=str(resources_line))
 
@@ -315,10 +334,23 @@ class AoE2GameOverlay(RTSGameOverlay):
             self.build_order_notes.add_row_color(
                 parent=self, height=layout.build_order.height_line_notes, color=layout.build_order.color_line_notes)
 
-            # notes of the current step
-            notes = selected_step['notes']
-            for note in notes:
-                self.build_order_notes.add_row_from_picture_line(parent=self, line=note)
+            # loop on the steps for notes
+            for step_id, selected_step in enumerate(selected_steps):
+
+                # check if emphasis must be added on the corresponding note
+                emphasis_flag = self.build_order_timer['run_timer'] and (step_id in selected_steps_ids)
+
+                notes = selected_step['notes']
+                for note_id, note in enumerate(notes):
+                    # add time if running timer and time available
+                    line = ''
+                    if (self.build_order_timer['use_timer']) and ('time' in resource_step) and hasattr(
+                            layout.build_order, 'show_time_in_notes') and layout.build_order.show_time_in_notes:
+                        line += (str(selected_step['time']) if (note_id == 0) else ' ') + '@' + spacing + '@'
+                        self.adapt_notes_to_columns = 1
+                    line += note
+                    self.build_order_notes.add_row_from_picture_line(
+                        parent=self, line=line, emphasis_flag=emphasis_flag)
 
         self.build_order_panel_layout()  # update layout
 
@@ -350,13 +382,19 @@ class AoE2GameOverlay(RTSGameOverlay):
         next_y += self.build_order_resources.row_total_height + vertical_spacing
 
         # maximum width
+        buttons_count = 3  # previous step + next step + next panel
+        if self.build_order_timer['available']:
+            buttons_count += 3 if self.build_order_timer[
+                'use_timer'] else 1  # switch timer-manual (+ start/stop + reset timer)
         max_x = max(
-            (self.build_order_step_time.width() + 3 * action_button_size +
-             horizontal_spacing + action_button_spacing + bo_next_tab_spacing),
+            (self.build_order_step_time.width() + buttons_count * action_button_size +
+             horizontal_spacing + (buttons_count - 2) * action_button_spacing + bo_next_tab_spacing),
             self.build_order_resources.row_max_width)
 
         # build order notes
-        self.build_order_notes.update_size_position(init_y=next_y, panel_init_width=max_x + 2 * border_size)
+        self.build_order_notes.update_size_position(
+            init_y=next_y, panel_init_width=max_x + 2 * border_size,
+            adapt_to_columns=self.adapt_notes_to_columns)
 
         # resize of the full window
         max_x = max(max_x, self.build_order_notes.row_max_width)

--- a/aoe2/aoe2_settings.py
+++ b/aoe2/aoe2_settings.py
@@ -60,7 +60,7 @@ class AoE2OverlaySettings(RTSOverlaySettings):
         self.hotkeys = RTSTimerHotkeys()
 
         # timer speed factor
-        self.timer_speed_factor = 1.606
+        self.timer_speed_factor = 1.608
 
 
 if __name__ == '__main__':

--- a/aoe2/aoe2_settings.py
+++ b/aoe2/aoe2_settings.py
@@ -60,7 +60,7 @@ class AoE2OverlaySettings(RTSOverlaySettings):
         self.hotkeys = RTSTimerHotkeys()
 
         # timer speed factor
-        self.timer_speed_factor = 1.7
+        self.timer_speed_factor = 1.606
 
 
 if __name__ == '__main__':

--- a/aoe2/aoe2_settings.py
+++ b/aoe2/aoe2_settings.py
@@ -59,6 +59,9 @@ class AoE2OverlaySettings(RTSOverlaySettings):
         # hotkeys
         self.hotkeys = RTSTimerHotkeys()
 
+        # timer speed factor
+        self.timer_speed_factor = 1.7
+
 
 if __name__ == '__main__':
     aoe2_settings_name = 'aoe2_settings.json'

--- a/aoe2/aoe2_settings.py
+++ b/aoe2/aoe2_settings.py
@@ -1,6 +1,6 @@
 import json
-from common.rts_settings import RTSConfigurationLayout, RTSLayout, RTSImages, RTSOverlaySettings, \
-    RTSBuildOrderLayout, RTSBuildOrderInputLayout, RTSHotkeys
+from common.rts_settings import RTSConfigurationLayout, RTSLayout, RTSOverlaySettings, \
+    RTSTimerImages, RTSBuildOrderTimerLayout, RTSTimerHotkeys
 
 
 class AoE2ConfigurationLayout(RTSConfigurationLayout):
@@ -19,10 +19,10 @@ class AoE2Layout(RTSLayout):
         """Constructor"""
         super().__init__()
         self.configuration: AoE2ConfigurationLayout = AoE2ConfigurationLayout()  # configuration layout
-        self.build_order: RTSBuildOrderLayout = RTSBuildOrderLayout()  # build order layout
+        self.build_order: RTSBuildOrderTimerLayout = RTSBuildOrderTimerLayout()  # build order layout
 
 
-class AoE2Images(RTSImages):
+class AoE2Images(RTSTimerImages):
     """Settings for the AoE2 images"""
 
     def __init__(self):
@@ -57,7 +57,7 @@ class AoE2OverlaySettings(RTSOverlaySettings):
         self.images = AoE2Images()
 
         # hotkeys
-        self.hotkeys = RTSHotkeys()
+        self.hotkeys = RTSTimerHotkeys()
 
 
 if __name__ == '__main__':

--- a/aoe2_overlay.py
+++ b/aoe2_overlay.py
@@ -12,6 +12,7 @@ if __name__ == '__main__':
 
     # timer to call the functions related to mouse and keyboard inputs
     timer = QTimer()
+    timer.timeout.connect(window.timer_build_order_call)
     timer.timeout.connect(window.timer_mouse_keyboard_call)
     timer.setInterval(window.settings.call_ms)
     timer.start()

--- a/aoe4/aoe4_build_order.py
+++ b/aoe4/aoe4_build_order.py
@@ -184,12 +184,13 @@ def get_aoe4_build_order_template() -> dict:
     }
 
 
-def evaluate_aoe4_build_order_timing(data: dict):
+def evaluate_aoe4_build_order_timing(data: dict, time_offset: int = 0):
     """Evaluate the time indications for an AoE4 build order.
 
     Parameters
     ----------
-    data    Data of the build order (will be updated).
+    data           Data of the build order (will be updated).
+    time_offset    Offset to add on the time outputs [sec].
     """
     # creation times [sec]
     villager_time: int = 20
@@ -201,4 +202,4 @@ def evaluate_aoe4_build_order_timing(data: dict):
     build_order_data = data['build_order']
     for step in build_order_data:
         villager_count = step['villager_count']
-        step['time'] = build_order_time_to_str(villager_time * villager_count)
+        step['time'] = build_order_time_to_str(villager_time * villager_count + time_offset)

--- a/aoe4/aoe4_build_order.py
+++ b/aoe4/aoe4_build_order.py
@@ -1,5 +1,5 @@
 from aoe4.aoe4_civ_icon import aoe4_civilization_icon
-from common.build_order_tools import is_valid_resource
+from common.build_order_tools import is_valid_resource, build_order_time_to_str
 
 
 def check_valid_aoe4_build_order(data: dict, bo_name_msg: bool = False) -> (bool, str):
@@ -182,3 +182,23 @@ def get_aoe4_build_order_template() -> dict:
         'source': 'Source',
         'build_order': [get_aoe4_build_order_step()]
     }
+
+
+def evaluate_aoe4_build_order_timing(data: dict):
+    """Evaluate the time indications for an AoE4 build order.
+
+    Parameters
+    ----------
+    data    Data of the build order (will be updated).
+    """
+    # creation times [sec]
+    villager_time: int = 20
+
+    if 'build_order' not in data:
+        print('The \'build_order\' field is missing from data when evaluating the timing.')
+        return
+
+    build_order_data = data['build_order']
+    for step in build_order_data:
+        villager_count = step['villager_count']
+        step['time'] = build_order_time_to_str(villager_time * villager_count)

--- a/aoe4/aoe4_build_order.py
+++ b/aoe4/aoe4_build_order.py
@@ -1,5 +1,5 @@
 from aoe4.aoe4_civ_icon import aoe4_civilization_icon
-from common.build_order_tools import is_valid_resource, build_order_time_to_str
+from common.build_order_tools import build_order_time_to_str
 
 
 def check_valid_aoe4_build_order(data: dict, bo_name_msg: bool = False) -> (bool, str):
@@ -90,20 +90,20 @@ def check_valid_aoe4_build_order(data: dict, bo_name_msg: bool = False) -> (bool
             if 'stone' not in resources:
                 return False, bo_name_str + f'{step_str} is missing the \'stone\' field in \'resources\'.'
 
-            if not is_valid_resource(resources['wood']):
+            if not isinstance(resources['wood'], int):
                 return False, bo_name_str + f'{step_str} has an invalid \'wood\' resource ({resources["wood"]}).'
 
-            if not is_valid_resource(resources['food']):
+            if not isinstance(resources['food'], int):
                 return False, bo_name_str + f'{step_str} has an invalid \'food\' resource ({resources["food"]}).'
 
-            if not is_valid_resource(resources['gold']):
+            if not isinstance(resources['gold'], int):
                 return False, bo_name_str + f'{step_str} has an invalid \'gold\' resource ({resources["gold"]}).'
 
-            if not is_valid_resource(resources['stone']):
+            if not isinstance(resources['stone'], int):
                 return False, bo_name_str + f'{step_str} has an invalid \'stone\' resource ({resources["stone"]}).'
 
             # optional builder count
-            if ('builder' in resources) and (not is_valid_resource(resources['builder'])):
+            if ('builder' in resources) and (not isinstance(resources['builder'], int)):
                 return False, bo_name_str + f'{step_str} has an invalid \'builder\' resource.'
 
             # notes

--- a/aoe4/aoe4_build_order.py
+++ b/aoe4/aoe4_build_order.py
@@ -3,17 +3,17 @@ from common.build_order_tools import build_order_time_to_str
 
 
 def check_valid_aoe4_build_order(data: dict, bo_name_msg: bool = False) -> (bool, str):
-    """Check if a build order is valid for AoE4
+    """Check if a build order is valid for AoE4.
 
     Parameters
     ----------
-    data           data of the build order JSON file
-    bo_name_msg    True to add the build order name in the error message
+    data           Data of the build order JSON file.
+    bo_name_msg    True to add the build order name in the error message.
 
     Returns
     -------
-    True if valid build order, False otherwise
-    string indicating the error (empty if no error)
+    True if valid build order, False otherwise.
+    String indicating the error (empty if no error).
     """
     bo_name_str: str = ''
     try:
@@ -126,7 +126,7 @@ def get_aoe4_build_order_step(build_order_data: dict = None) -> dict:
 
     Parameters
     ----------
-    build_order_data    data with the build order
+    build_order_data    Data with the build order.
 
     Returns
     -------

--- a/aoe4/aoe4_build_order.py
+++ b/aoe4/aoe4_build_order.py
@@ -136,7 +136,7 @@ def get_aoe4_build_order_step(build_order_data: dict = None) -> dict:
         assert isinstance(build_order_data, list) and len(build_order_data) >= 1
         data = build_order_data[-1]  # last step data
         return {
-            'population_count': data['population_count'] if ('population_count' in data) else 0,
+            'population_count': data['population_count'] if ('population_count' in data) else -1,
             'villager_count': data['villager_count'] if ('villager_count' in data) else 0,
             'age': data['age'] if ('age' in data) else 1,
             'resources': data['resources'] if ('resources' in data) else {
@@ -152,7 +152,7 @@ def get_aoe4_build_order_step(build_order_data: dict = None) -> dict:
         }
     else:
         return {
-            'population_count': 0,
+            'population_count': -1,
             'villager_count': 0,
             'age': 1,
             'resources': {

--- a/aoe4/aoe4_build_order.py
+++ b/aoe4/aoe4_build_order.py
@@ -334,8 +334,9 @@ def evaluate_aoe4_build_order_timing(data: dict, time_offset: int = 0):
         return
 
     build_order_data = data['build_order']
+    step_count = len(build_order_data)
 
-    for step in build_order_data:  # loop on all the build order steps
+    for step_id, step in enumerate(build_order_data):  # loop on all the build order steps
 
         step_total_time: float = 0.0  # total time for this step
 
@@ -370,3 +371,8 @@ def evaluate_aoe4_build_order_timing(data: dict, time_offset: int = 0):
 
         # update build order with time
         step['time'] = build_order_time_to_str(int(round(last_time_sec)))
+
+        # special case for last step (add 1 sec to avoid displaying both at the same time)
+        if (step_id == step_count - 1) and (step_count >= 2) and (
+                step['time'] == build_order_data[step_id - 1]['time']):
+            step['time'] = build_order_time_to_str(int(round(last_time_sec + 1.0)))

--- a/aoe4/aoe4_build_order.py
+++ b/aoe4/aoe4_build_order.py
@@ -121,28 +121,51 @@ def check_valid_aoe4_build_order(data: dict, bo_name_msg: bool = False) -> (bool
     return True, ''  # valid build order, no error message
 
 
-def get_aoe4_build_order_step() -> dict:
+def get_aoe4_build_order_step(build_order_data: dict = None) -> dict:
     """Get one step of the AoE4 build order (template).
+
+    Parameters
+    ----------
+    build_order_data    data with the build order
 
     Returns
     -------
     Dictionary with the build order step template.
     """
-    return {
-        'population_count': 0,
-        'villager_count': 0,
-        'age': 1,
-        'resources': {
-            'food': 0,
-            'wood': 0,
-            'gold': 0,
-            'stone': 0
-        },
-        'notes': [
-            'Note 1.',
-            'Note 2.'
-        ]
-    }
+    if build_order_data is not None:
+        assert isinstance(build_order_data, list) and len(build_order_data) >= 1
+        data = build_order_data[-1]  # last step data
+        return {
+            'population_count': data['population_count'] if ('population_count' in data) else 0,
+            'villager_count': data['villager_count'] if ('villager_count' in data) else 0,
+            'age': data['age'] if ('age' in data) else 1,
+            'resources': data['resources'] if ('resources' in data) else {
+                'food': 0,
+                'wood': 0,
+                'gold': 0,
+                'stone': 0
+            },
+            'notes': [
+                'Note 1.',
+                'Note 2.'
+            ]
+        }
+    else:
+        return {
+            'population_count': 0,
+            'villager_count': 0,
+            'age': 1,
+            'resources': {
+                'food': 0,
+                'wood': 0,
+                'gold': 0,
+                'stone': 0
+            },
+            'notes': [
+                'Note 1.',
+                'Note 2.'
+            ]
+        }
 
 
 def get_aoe4_build_order_template() -> dict:

--- a/aoe4/aoe4_build_order.py
+++ b/aoe4/aoe4_build_order.py
@@ -260,8 +260,6 @@ def get_town_center_unit_research_time(name: str, civilization_flags: dict, curr
             return 25.0
         else:
             return update_town_center_time(20.0, civilization_flags, current_age)
-    elif name == 'fresh foodstuffs':
-        return 20.0 if civilization_flags['Abbasid'] else 0.0
     elif name == 'imperial official':
         # Only for Chinese in Dark Age (assuming Chinese Imperial Academy in Feudal and starting with 1 for Zhu Xi).
         if civilization_flags['Chinese'] and (current_age == 1):
@@ -306,7 +304,6 @@ def evaluate_aoe4_build_order_timing(data: dict, time_offset: int = 0):
     # TC technologies or special units
     tc_unit_technologies = {
         'textiles': 'technology_economy/textiles.png',
-        'fresh foodstuffs': 'technology_abbasid/fresh-foodstuffs.png',
         'imperial official': 'unit_chinese/imperial-official.png'
         # The following technologies/units are not analyzed:
         #     * Banco Repairs (Malians) is usually researched after 2nd TC.

--- a/aoe4/aoe4_game_overlay.py
+++ b/aoe4/aoe4_game_overlay.py
@@ -8,7 +8,6 @@ from PyQt5.QtCore import QSize
 from common.useful_tools import widget_x_end, widget_y_end
 from common.rts_overlay import RTSGameOverlay, scale_list_int, PanelID
 from common.build_order_window import BuildOrderWindow
-from common.build_order_tools import get_build_order_timer_steps_display
 
 from aoe4.aoe4_settings import AoE4OverlaySettings
 from aoe4.aoe4_build_order import check_valid_aoe4_build_order
@@ -18,15 +17,15 @@ from aoe4.aoe4_civ_icon import aoe4_civilization_icon, get_aoe4_faction_selectio
 
 
 class AoE4GameOverlay(RTSGameOverlay):
-    """Game overlay application for AoE4"""
+    """Game overlay application for AoE4."""
 
     def __init__(self, app: QApplication, directory_main: str):
         """Constructor
 
         Parameters
         ----------
-        app               main application instance
-        directory_main    directory where the main file is located
+        app               Main application instance.
+        directory_main    Directory where the main file is located.
         """
         super().__init__(app=app, directory_main=directory_main, name_game='aoe4', settings_name='aoe4_settings.json',
                          settings_class=AoE4OverlaySettings, check_valid_build_order=check_valid_aoe4_build_order,
@@ -83,9 +82,6 @@ class AoE4GameOverlay(RTSGameOverlay):
         self.civilization_select.setFont(QFont(layout.font_police, layout.font_size))
         self.civilization_select.adjustSize()
 
-        # create build orders folder
-        os.makedirs(self.directory_build_orders, exist_ok=True)
-
         self.update_panel_elements()  # update the current panel elements
 
     def reload(self, update_settings):
@@ -93,7 +89,7 @@ class AoE4GameOverlay(RTSGameOverlay):
 
         Parameters
         ----------
-        update_settings   True to update (reload) the settings, False to keep the current ones
+        update_settings   True to update (reload) the settings, False to keep the current ones.
         """
         super().reload(update_settings=update_settings)
 
@@ -111,28 +107,50 @@ class AoE4GameOverlay(RTSGameOverlay):
         self.update_panel_elements()  # update the current panel elements
 
     def settings_scaling(self):
-        """Apply the scaling on the settings"""
+        """Apply the scaling on the settings."""
         super().settings_scaling()
         assert 0 <= self.scaling_input_selected_id < len(self.scaling_input_combo_ids)
-        layout = self.settings.layout
-        unscaled_layout = self.unscaled_settings.layout
         scaling = self.scaling_input_combo_ids[self.scaling_input_selected_id] / 100.0
 
-        layout.configuration.flag_select_size = scale_list_int(
-            scaling, unscaled_layout.configuration.flag_select_size)
+        self.settings.layout.configuration.flag_select_size = scale_list_int(
+            scaling, self.unscaled_settings.layout.configuration.flag_select_size)
+
+    def select_build_order_id(self, build_order_id: int = -1) -> bool:
+        """Select build order ID.
+
+        Parameters
+        ----------
+        build_order_id    ID of the build order, negative to select next build order.
+
+        Returns
+        -------
+        True if valid build order selection.
+        """
+        if self.selected_panel == PanelID.CONFIG:
+            if super().select_build_order_id(build_order_id):
+                civilization_id = self.civilization_select.currentIndex()
+                assert 0 <= civilization_id < len(self.civilization_combo_ids)
+                self.obtain_build_order_search(
+                    key_condition={'civilization': self.civilization_combo_ids[civilization_id]})
+                if build_order_id >= 0:  # directly select in case of clicking
+                    self.select_build_order(key_condition={
+                        'civilization': self.civilization_combo_ids[self.civilization_select.currentIndex()]})
+                self.config_panel_layout()
+                return True
+        return False
 
     def hide_elements(self):
-        """Hide elements"""
+        """Hide elements."""
         super().hide_elements()
 
         self.civilization_select.hide()
 
     def get_age_image(self, age_id: int) -> str:
-        """Get the image for a requested age
+        """Get the image for a requested age.
 
         Parameters
         ----------
-        age_id    ID of the age
+        age_id    ID of the age.
 
         Returns
         -------
@@ -150,15 +168,42 @@ class AoE4GameOverlay(RTSGameOverlay):
             return self.settings.images.age_unknown
 
     def update_build_order_display(self):
-        """Update the build order search matching display"""
+        """Update the build order search matching display."""
         civilization_id = self.civilization_select.currentIndex()
         assert 0 <= civilization_id < len(self.civilization_combo_ids)
         self.obtain_build_order_search(key_condition={'civilization': self.civilization_combo_ids[civilization_id]})
         self.config_panel_layout()
 
+    def enter_key_actions(self):
+        """Actions performed when pressing the Enter key."""
+        if self.selected_panel == PanelID.CONFIG:
+            if self.build_order_search.hasFocus():
+                self.select_build_order(key_condition={
+                    'civilization': self.civilization_combo_ids[self.civilization_select.currentIndex()]})
+
+            self.config_panel_layout()  # update layout
+
+    def open_panel_add_build_order(self):
+        """Open/close the panel to add a build order."""
+        super().open_panel_add_build_order()
+
+        if (self.panel_add_build_order is not None) and self.panel_add_build_order.isVisible():  # close panel
+            self.panel_add_build_order.close()
+            self.panel_add_build_order = None
+        else:  # open new panel
+            self.panel_add_build_order = BuildOrderWindow(
+                app=self.app, parent=self, game_icon=self.game_icon, build_order_folder=self.directory_build_orders,
+                panel_settings=self.settings.panel_build_order, edit_init_text=self.build_order_instructions,
+                build_order_websites=[['aoe4guides.com', 'https://aoe4guides.com'],
+                                      ['age4builder.com', 'https://age4builder.com']],
+                directory_game_pictures=self.directory_game_pictures,
+                directory_common_pictures=self.directory_common_pictures)
+
     def config_panel_layout(self):
-        """Layout of the configuration panel"""
+        """Layout of the configuration panel."""
         super().config_panel_layout()
+        if self.selected_panel != PanelID.CONFIG:
+            return
 
         # show elements
         self.civilization_select.show()
@@ -198,85 +243,24 @@ class AoE4GameOverlay(RTSGameOverlay):
 
         self.build_order_selection.update_size_position(init_y=next_y)
 
-        max_x = max(widget_x_end(self.next_panel_button), widget_x_end(self.build_order_search),
-                    self.build_order_selection.x() + self.build_order_selection.row_max_width)
-
-        max_y = max(widget_y_end(self.build_order_search),
-                    self.build_order_selection.y() + self.build_order_selection.row_total_height)
-
-        # resize main window
-        self.resize(max_x + border_size, max_y + border_size)
-
-        # next panel on top right corner
-        self.next_panel_button.move(self.width() - border_size - self.next_panel_button.width(), border_size)
-
-        # update position (in case the size changed)
-        self.update_position()
-
-    def select_build_order_id(self, build_order_id: int = -1) -> bool:
-        """Select build order ID
-
-        Parameters
-        ----------
-        build_order_id    ID of the build order, negative to select next build order
-
-        Returns
-        -------
-        True if valid build order selection
-        """
-        if self.selected_panel == PanelID.CONFIG:
-            if super().select_build_order_id(build_order_id):
-                civilization_id = self.civilization_select.currentIndex()
-                assert 0 <= civilization_id < len(self.civilization_combo_ids)
-                self.obtain_build_order_search(
-                    key_condition={'civilization': self.civilization_combo_ids[civilization_id]})
-                if build_order_id >= 0:  # directly select in case of clicking
-                    self.select_build_order(key_condition={
-                        'civilization': self.civilization_combo_ids[self.civilization_select.currentIndex()]})
-                self.config_panel_layout()
-                return True
-        return False
+        self.config_panel_layout_resize_move()  # size and position
 
     def update_build_order(self):
-        """Update the build order panel"""
+        """Update the build order panel."""
         super().update_build_order()
-
-        layout = self.settings.layout
-        self.adapt_notes_to_columns = -1  # no column adaptation by default
 
         # valid build order selected
         if (self.selected_build_order is not None) and ('build_order' in self.selected_build_order):
 
-            if self.build_order_timer['use_timer'] and self.build_order_timer['steps']:
-                # get steps to display
-                selected_steps_ids, selected_steps = get_build_order_timer_steps_display(
-                    self.build_order_timer['steps'], self.build_order_timer['steps_ids'])
-            else:
-                selected_build_order_content = self.selected_build_order['build_order']
+            layout = self.settings.layout
+            spacing = ' ' * layout.build_order.resource_spacing  # space between the elements
 
-                # select current step
-                assert 0 <= self.selected_build_order_step_id < self.selected_build_order_step_count
-                selected_steps_ids = [0]
-                selected_steps = [selected_build_order_content[self.selected_build_order_step_id]]
-                assert selected_steps[0] is not None
-            assert (len(selected_steps) > 0) and (len(selected_steps_ids) > 0)
-
-            # space between the elements
-            spacing = ''
-            for i in range(layout.build_order.resource_spacing):
-                spacing += ' '
-
-            # display selected step
-            if self.build_order_timer['use_timer']:
-                self.update_build_order_time_label()
-            else:
-                self.update_build_order_step_label()
-
-            images = self.settings.images
+            # get selected steps and corresponding IDs
+            selected_steps, selected_steps_ids = self.get_build_order_selected_steps_and_ids()
 
             # resource line
+            images = self.settings.images
             resource_step = selected_steps[selected_steps_ids[-1]]  # ID of the step to use to display the resources
-            resources_line = ''
 
             # target resources
             target_resources = resource_step['resources']
@@ -308,100 +292,7 @@ class AoE4GameOverlay(RTSGameOverlay):
 
             self.build_order_resources.add_row_from_picture_line(parent=self, line=str(resources_line))
 
-            # loop on the steps for notes
-            for step_id, selected_step in enumerate(selected_steps):
-
-                # check if emphasis must be added on the corresponding note
-                emphasis_flag = self.build_order_timer['run_timer'] and (step_id in selected_steps_ids)
-
-                notes = selected_step['notes']
-                for note_id, note in enumerate(notes):
-                    # add time if running timer and time available
-                    line = ''
-                    if (self.build_order_timer['use_timer']) and ('time' in resource_step) and hasattr(
-                            layout.build_order, 'show_time_in_notes') and layout.build_order.show_time_in_notes:
-                        line += (str(selected_step['time']) if (note_id == 0) else ' ') + '@' + spacing + '@'
-                        self.adapt_notes_to_columns = 1
-                    line += note
-                    self.build_order_notes.add_row_from_picture_line(
-                        parent=self, line=line, emphasis_flag=emphasis_flag)
+            # update the notes of the build order
+            self.update_build_order_notes(selected_steps, selected_steps_ids)
 
         self.build_order_panel_layout()  # update layout
-
-    def build_order_panel_layout(self):
-        """Layout of the Build order panel"""
-        super().build_order_panel_layout()
-
-        # show elements
-        self.build_order_resources.show()
-
-        # size and position
-        layout = self.settings.layout
-        border_size = layout.border_size
-        vertical_spacing = layout.vertical_spacing
-        horizontal_spacing = layout.horizontal_spacing
-        action_button_size = layout.action_button_size
-        action_button_spacing = layout.action_button_spacing
-        bo_next_tab_spacing = layout.build_order.bo_next_tab_spacing
-
-        # action buttons
-        next_y = border_size + action_button_size + vertical_spacing
-
-        if self.selected_build_order is not None:
-            self.build_order_step_time.adjustSize()
-            next_y = max(next_y, border_size + self.build_order_step_time.height() + vertical_spacing)
-
-        # build order resources
-        self.build_order_resources.update_size_position(init_y=next_y)
-        next_y += self.build_order_resources.row_total_height + vertical_spacing
-
-        # maximum width
-        buttons_count = 3  # previous step + next step + next panel
-        if self.build_order_timer['available']:
-            buttons_count += 3 if self.build_order_timer[
-                'use_timer'] else 1  # switch timer-manual (+ start/stop + reset timer)
-        max_x = max(
-            (self.build_order_step_time.width() + buttons_count * action_button_size +
-             horizontal_spacing + (buttons_count - 2) * action_button_spacing + bo_next_tab_spacing),
-            self.build_order_resources.row_max_width)
-
-        # build order notes
-        self.build_order_notes.update_size_position(
-            init_y=next_y, panel_init_width=max_x + 2 * border_size,
-            adapt_to_columns=self.adapt_notes_to_columns)
-
-        # resize of the full window
-        max_x = max(max_x, self.build_order_notes.row_max_width)
-        self.resize(max_x + 2 * border_size, next_y + self.build_order_notes.row_total_height + border_size)
-
-        # adapt buttons positions after window resize
-        self.build_order_panel_layout_action_buttons()
-
-        # position update to stay with the same upper right corner position
-        self.update_position()
-
-    def enter_key_actions(self):
-        """Actions performed when pressing the Enter key"""
-        if self.selected_panel == PanelID.CONFIG:
-            if self.build_order_search.hasFocus():
-                self.select_build_order(key_condition={
-                    'civilization': self.civilization_combo_ids[self.civilization_select.currentIndex()]})
-
-            self.config_panel_layout()  # update layout
-
-    def open_panel_add_build_order(self):
-        """Open/close the panel to add a build order"""
-        super().open_panel_add_build_order()
-
-        if (self.panel_add_build_order is not None) and self.panel_add_build_order.isVisible():  # close panel
-            self.panel_add_build_order.close()
-            self.panel_add_build_order = None
-        else:  # open new panel
-            config = self.settings.panel_build_order
-            self.panel_add_build_order = BuildOrderWindow(
-                app=self.app, parent=self, game_icon=self.game_icon, build_order_folder=self.directory_build_orders,
-                panel_settings=self.settings.panel_build_order, edit_init_text=self.build_order_instructions,
-                build_order_websites=[['aoe4guides.com', 'https://aoe4guides.com'],
-                                      ['age4builder.com', 'https://age4builder.com']],
-                directory_game_pictures=self.directory_game_pictures,
-                directory_common_pictures=self.directory_common_pictures)

--- a/aoe4/aoe4_game_overlay.py
+++ b/aoe4/aoe4_game_overlay.py
@@ -302,7 +302,8 @@ class AoE4GameOverlay(RTSGameOverlay):
                 resources_line += spacing + '@' + images.population + '@ ' + str(target_population)
             if 1 <= resource_step['age'] <= 4:
                 resources_line += spacing + '@' + self.get_age_image(resource_step['age'])
-            if ('time' in resource_step) and (resource_step['time'] != ''):  # add time if indicated
+            # add time if indicated
+            if layout.show_time_resource and ('time' in resource_step) and (resource_step['time'] != ''):
                 resources_line += '@' + spacing + '@' + self.settings.images.time + '@' + resource_step['time']
 
             self.build_order_resources.add_row_from_picture_line(parent=self, line=str(resources_line))

--- a/aoe4/aoe4_game_overlay.py
+++ b/aoe4/aoe4_game_overlay.py
@@ -368,6 +368,8 @@ class AoE4GameOverlay(RTSGameOverlay):
 
     def open_panel_add_build_order(self):
         """Open/close the panel to add a build order"""
+        super().open_panel_add_build_order()
+
         if (self.panel_add_build_order is not None) and self.panel_add_build_order.isVisible():  # close panel
             self.panel_add_build_order.close()
             self.panel_add_build_order = None

--- a/aoe4/aoe4_game_overlay.py
+++ b/aoe4/aoe4_game_overlay.py
@@ -238,15 +238,10 @@ class AoE4GameOverlay(RTSGameOverlay):
 
     def update_build_order(self):
         """Update the build order panel"""
+        super().update_build_order()
 
-        # clear the elements (also hide them)
-        self.build_order_resources.clear()
-        self.build_order_notes.clear()
-
-        if self.selected_build_order is None:  # no build order selected
-            self.build_order_notes.add_row_from_picture_line(parent=self, line='No build order selected.')
-
-        else:  # valid build order selected
+        # valid build order selected
+        if (self.selected_build_order is not None) and ('build_order' in self.selected_build_order):
             selected_build_order_content = self.selected_build_order['build_order']
 
             # select current step

--- a/aoe4/aoe4_game_overlay.py
+++ b/aoe4/aoe4_game_overlay.py
@@ -5,7 +5,6 @@ from PyQt5.QtWidgets import QComboBox, QApplication
 from PyQt5.QtGui import QIcon, QFont
 from PyQt5.QtCore import QSize
 
-from common.build_order_tools import get_total_on_resource
 from common.useful_tools import widget_x_end, widget_y_end
 from common.rts_overlay import RTSGameOverlay, scale_list_int, PanelID
 from common.build_order_window import BuildOrderWindow
@@ -60,8 +59,6 @@ class AoE4GameOverlay(RTSGameOverlay):
             '\n\nYou can find all your saved build orders as JSON files by clicking on \'Open build orders folder\'.' \
             '\nTo remove any build order, just delete the corresponding file and use \'reload settings\' ' \
             '(or relaunch the overlay).'
-
-        self.bo_tooltip_available = True  # activate tooltip feature in build order
 
         # civilization selection
         layout = self.settings.layout
@@ -253,12 +250,11 @@ class AoE4GameOverlay(RTSGameOverlay):
 
             # target resources
             target_resources = selected_step['resources']
-            target_food = get_total_on_resource(target_resources['food'])
-            target_wood = get_total_on_resource(target_resources['wood'])
-            target_gold = get_total_on_resource(target_resources['gold'])
-            target_stone = get_total_on_resource(target_resources['stone'])
-            target_builder = get_total_on_resource(target_resources['builder']) if (
-                    'builder' in target_resources) else -1
+            target_food = target_resources['food']
+            target_wood = target_resources['wood']
+            target_gold = target_resources['gold']
+            target_stone = target_resources['stone']
+            target_builder = target_resources['builder'] if ('builder' in target_resources) else -1
             target_villager = selected_step['villager_count']
             target_population = selected_step['population_count']
 
@@ -290,12 +286,7 @@ class AoE4GameOverlay(RTSGameOverlay):
             if ('time' in selected_step) and (selected_step['time'] != ''):  # add time if indicated
                 resources_line += '@' + spacing + '@' + self.settings.images.time + '@' + selected_step['time']
 
-            # for dict type target_resources, create a tooltip to associate with the resource icon
-            mapping = {'wood': images.wood, 'food': images.food, 'gold': images.gold, 'stone': images.stone}
-            tooltip = dict(
-                (mapping[key], value) for (key, value) in target_resources.items() if type(value) is dict)
-            self.build_order_resources.add_row_from_picture_line(
-                parent=self, line=str(resources_line), tooltips=tooltip)
+            self.build_order_resources.add_row_from_picture_line(parent=self, line=str(resources_line))
 
             # line before notes
             self.build_order_notes.add_row_color(

--- a/aoe4/aoe4_game_overlay.py
+++ b/aoe4/aoe4_game_overlay.py
@@ -12,7 +12,8 @@ from common.build_order_window import BuildOrderWindow
 
 from aoe4.aoe4_settings import AoE4OverlaySettings
 from aoe4.aoe4_build_order import check_valid_aoe4_build_order
-from aoe4.aoe4_build_order import get_aoe4_build_order_step, get_aoe4_build_order_template
+from aoe4.aoe4_build_order import get_aoe4_build_order_step, get_aoe4_build_order_template, \
+    evaluate_aoe4_build_order_timing
 from aoe4.aoe4_civ_icon import aoe4_civilization_icon, get_aoe4_faction_selection
 
 
@@ -32,6 +33,7 @@ class AoE4GameOverlay(RTSGameOverlay):
                          get_build_order_step=get_aoe4_build_order_step,
                          get_build_order_template=get_aoe4_build_order_template,
                          get_faction_selection=get_aoe4_faction_selection,
+                         evaluate_build_order_timing=evaluate_aoe4_build_order_timing,
                          build_order_category_name='civilization')
 
         # build order instructions

--- a/aoe4/aoe4_settings.py
+++ b/aoe4/aoe4_settings.py
@@ -1,6 +1,6 @@
 import json
-from common.rts_settings import RTSConfigurationLayout, RTSLayout, RTSImages, RTSOverlaySettings, \
-    RTSBuildOrderLayout, RTSBuildOrderInputLayout, RTSHotkeys
+from common.rts_settings import RTSConfigurationLayout, RTSLayout, RTSOverlaySettings, \
+    RTSTimerImages, RTSBuildOrderTimerLayout, RTSTimerHotkeys
 
 
 class AoE4ConfigurationLayout(RTSConfigurationLayout):
@@ -19,10 +19,10 @@ class AoE4Layout(RTSLayout):
         """Constructor"""
         super().__init__()
         self.configuration: AoE4ConfigurationLayout = AoE4ConfigurationLayout()  # configuration layout
-        self.build_order: RTSBuildOrderLayout = RTSBuildOrderLayout()  # build order layout
+        self.build_order: RTSBuildOrderTimerLayout = RTSBuildOrderTimerLayout()  # build order layout
 
 
-class AoE4Images(RTSImages):
+class AoE4Images(RTSTimerImages):
     """Settings for the AoE4 images"""
 
     def __init__(self):
@@ -58,7 +58,7 @@ class AoE4OverlaySettings(RTSOverlaySettings):
         self.images = AoE4Images()
 
         # hotkeys
-        self.hotkeys = RTSHotkeys()
+        self.hotkeys = RTSTimerHotkeys()
 
 
 if __name__ == '__main__':

--- a/aoe4_overlay.py
+++ b/aoe4_overlay.py
@@ -12,6 +12,7 @@ if __name__ == '__main__':
 
     # timer to call the functions related to mouse and keyboard inputs
     timer = QTimer()
+    timer.timeout.connect(window.timer_build_order_call)
     timer.timeout.connect(window.timer_mouse_keyboard_call)
     timer.setInterval(window.settings.call_ms)
     timer.start()

--- a/build_orders/aoe2/all_in_scouts.json
+++ b/build_orders/aoe2/all_in_scouts.json
@@ -3,14 +3,13 @@
     "civilization": "Generic",
     "author": "Hera",
     "source": "https://discord.com/invite/RdnZdZRkCq (Hera Discord)",
-    "build_order": [{
+    "build_order": [
+        {
             "villager_count": 6,
             "age": 1,
             "resources": {
                 "wood": 0,
-                "food": {
-                    "animal/Sheep_aoe2DE.png": 6
-                },
+                "food": 6,
                 "gold": 0,
                 "stone": 0
             },
@@ -24,9 +23,7 @@
             "age": 1,
             "resources": {
                 "wood": 3,
-                "food": {
-                    "animal/Sheep_aoe2DE.png": 6
-                },
+                "food": 6,
                 "gold": 0,
                 "stone": 0
             },
@@ -40,9 +37,7 @@
             "age": 1,
             "resources": {
                 "wood": 3,
-                "food": {
-                    "animal/Boar_aoe2DE.png": 7
-                },
+                "food": 7,
                 "gold": 0,
                 "stone": 0
             },
@@ -55,9 +50,7 @@
             "age": 1,
             "resources": {
                 "wood": 3,
-                "food": {
-                    "animal/Boar_aoe2DE.png": 8
-                },
+                "food": 8,
                 "gold": 0,
                 "stone": 0
             },
@@ -70,10 +63,7 @@
             "age": 1,
             "resources": {
                 "wood": 3,
-                "food": {
-                    "animal/Boar_aoe2DE.png": 8,
-                    "resource/BerryBushDE.png": 1
-                },
+                "food": 9,
                 "gold": 0,
                 "stone": 0
             },
@@ -87,10 +77,7 @@
             "age": 1,
             "resources": {
                 "wood": 3,
-                "food": {
-                    "animal/Boar_aoe2DE.png": 8,
-                    "resource/BerryBushDE.png": 3
-                },
+                "food": 11,
                 "gold": 0,
                 "stone": 0
             },
@@ -103,10 +90,7 @@
             "age": 1,
             "resources": {
                 "wood": 3,
-                "food": {
-                    "animal/Boar_aoe2DE.png": 9,
-                    "resource/BerryBushDE.png": 3
-                },
+                "food": 12,
                 "gold": 0,
                 "stone": 0
             },
@@ -119,10 +103,7 @@
             "age": 1,
             "resources": {
                 "wood": 3,
-                "food": {
-                    "animal/Boar_aoe2DE.png": 9,
-                    "resource/BerryBushDE.png": 4
-                },
+                "food": 13,
                 "gold": 0,
                 "stone": 0
             },
@@ -135,10 +116,7 @@
             "age": 1,
             "resources": {
                 "wood": 3,
-                "food": {
-                    "animal/Boar_aoe2DE.png": 10,
-                    "resource/BerryBushDE.png": 4
-                },
+                "food": 14,
                 "gold": 0,
                 "stone": 0
             },
@@ -151,10 +129,7 @@
             "age": 1,
             "resources": {
                 "wood": 5,
-                "food": {
-                    "animal/Boar_aoe2DE.png": 10,
-                    "resource/BerryBushDE.png": 4
-                },
+                "food": 14,
                 "gold": 0,
                 "stone": 0
             },
@@ -167,10 +142,7 @@
             "age": 1,
             "resources": {
                 "wood": 6,
-                "food": {
-                    "animal/Boar_aoe2DE.png": 10,
-                    "resource/BerryBushDE.png": 4
-                },
+                "food": 14,
                 "gold": 0,
                 "stone": 0
             },
@@ -184,10 +156,7 @@
             "age": 2,
             "resources": {
                 "wood": 9,
-                "food": {
-                    "animal/Boar_aoe2DE.png": 7,
-                    "resource/BerryBushDE.png": 4
-                },
+                "food": 11,
                 "gold": 0,
                 "stone": 0
             },

--- a/common/build_order_tools.py
+++ b/common/build_order_tools.py
@@ -5,13 +5,13 @@ from common.useful_tools import list_directory_files
 
 
 def is_build_order_new(existing_build_orders: list, new_build_order_data: dict, category_name: str = None) -> bool:
-    """Check if a build order is new
+    """Check if a build order is new.
 
     Parameters
     ----------
-    existing_build_orders    list of existing build orders
-    new_build_order_data     new build order data
-    category_name            if not None, accept build orders with same name, if they are in different categories
+    existing_build_orders    List of existing build orders.
+    new_build_order_data     New build order data.
+    category_name            If not None, accept build orders with same name, if they are in different categories.
 
     Returns
     -------
@@ -26,17 +26,17 @@ def is_build_order_new(existing_build_orders: list, new_build_order_data: dict, 
 
 
 def get_build_orders(directory: str, check_valid_build_order, category_name: str = None) -> list:
-    """Get the build orders
+    """Get the build orders.
 
     Parameters
     ----------
-    directory                  directory where the JSON build orders are located
-    check_valid_build_order    function to check if a build order is valid
-    category_name              if not None, accept build orders with same name, if they are in different categories
+    directory                  Directory where the JSON build orders are located.
+    check_valid_build_order    Function to check if a build order is valid.
+    category_name              If not None, accept build orders with same name, if they are in different categories.
 
     Returns
     -------
-    list of valid build orders
+    list of valid build orders.
     """
     build_order_files = list_directory_files(directory, extension='.json')
 
@@ -69,16 +69,16 @@ def get_build_orders(directory: str, check_valid_build_order, category_name: str
 
 
 def check_build_order_key_values(build_order: dict, key_condition: dict = None) -> bool:
-    """Check if a build order fulfills the correct key conditions
+    """Check if a build order fulfills the correct key conditions.
 
     Parameters
     ----------
-    build_order      build order to check
-    key_condition    dictionary with the keys to look for and their value (to consider as valid), None to skip it
+    build_order      Build order to check.
+    key_condition    Dictionary with the keys to look for and their value (to consider as valid), None to skip it.
 
     Returns
     -------
-    True if no key condition or key conditions are correct
+    True if no key condition or key conditions are correct.
     """
     if key_condition is None:  # no key condition to check
         return True
@@ -103,16 +103,16 @@ def convert_txt_note_to_illustrated(note: str, convert_dict: dict, to_lower: boo
 
     Parameters
     ----------
-    note              note in raw TXT
-    convert_dict      dictionary for conversions
-    to_lower          True to look in the dictionary with key set in lower case
-    max_size          maximal size of the split note pattern, less than 1 to take the full split length
-    ignore_in_dict    list of symbols to ignore when checking if it is in the dictionary,
-                      None if nothing to ignore
+    note              Note in raw TXT.
+    convert_dict      Dictionary for conversions.
+    to_lower          True to look in the dictionary with key set in lower case.
+    max_size          Maximal size of the split note pattern, less than 1 to take the full split length.
+    ignore_in_dict    List of symbols to ignore when checking if it is in the dictionary,
+                      None if nothing to ignore.
 
     Returns
     -------
-    updated note (potentially with illustration)
+    Updated note (potentially with illustration).
     """
 
     note_split = note.split(' ')  # note split based on spaces
@@ -252,7 +252,7 @@ def build_order_time_to_sec(time_str: str) -> int:
 
 
 def check_valid_build_order_timer(data: dict) -> bool:
-    """Check if a build order is valid to use a timer.
+    """Check if a build order can use the timer feature.
 
     Parameters
     ----------
@@ -283,7 +283,7 @@ def check_valid_build_order_timer(data: dict) -> bool:
 
 
 def get_build_order_timer_steps(data: dict) -> list:
-    """Check if a build order is valid to use a timer and return the corresponding steps.
+    """Check if a build order can use the timer feature and return the corresponding steps.
 
     Parameters
     ----------

--- a/common/build_order_tools.py
+++ b/common/build_order_tools.py
@@ -68,43 +68,6 @@ def get_build_orders(directory: str, check_valid_build_order, category_name: str
     return build_orders
 
 
-def is_valid_resource(resource: [int, dict]) -> bool:
-    """Checks if a resource is valid. It can either be an integer or a list of sub resources.
-
-    Parameters
-    ----------
-    resource    int or dict of resources
-
-    Returns
-    -------
-    boolean, if the resource is valid
-    """
-    if isinstance(resource, int):
-        return True
-    if isinstance(resource, dict) and all([isinstance(sub_resource, int) for sub_resource in resource.values()]):
-        return True
-    return False
-
-
-def get_total_on_resource(resource: [int, dict]) -> int:
-    """Gets an integer from either an int or a dict of sub resources.
-
-    Parameters
-    ----------
-    resource    int or dict of resources
-
-    Returns
-    -------
-    integer amount of villagers on that resource
-    """
-    if isinstance(resource, int):
-        return resource
-    elif isinstance(resource, dict):
-        return sum([sub_resource for sub_resource in resource.values()])
-    else:
-        raise AttributeError("Unexpected resource data type.")
-
-
 def check_build_order_key_values(build_order: dict, key_condition: dict = None) -> bool:
     """Check if a build order fulfills the correct key conditions
 

--- a/common/build_order_tools.py
+++ b/common/build_order_tools.py
@@ -237,6 +237,23 @@ def convert_txt_note_to_illustrated(note: str, convert_dict: dict, to_lower: boo
     return note
 
 
+def build_order_time_to_str(time_sec: int) -> str:
+    """Convert a time in seconds to the corresponding string (as 'x:xx').
+
+    Parameters
+    ----------
+    time_sec    Time in seconds.
+
+    Returns
+    -------
+    Corresponding string (as 'x:xx'), '0:00' if not valid (or negative) time.
+    """
+    if not isinstance(time_sec, int) or time_sec <= 0:
+        return '0:00'
+
+    return str(time_sec // 60) + ':' + f'{(time_sec % 60):02}'
+
+
 def build_order_time_to_sec(time_str: str) -> int:
     """Convert a string with time (as 'x:xx') to a number of seconds.
 

--- a/common/build_order_tools.py
+++ b/common/build_order_tools.py
@@ -319,34 +319,45 @@ def get_build_order_timer_steps(data: dict) -> list:
     return full_steps
 
 
-def get_build_order_timer_step_ids(steps: list, current_time_sec: int) -> list:
+def get_build_order_timer_step_ids(steps: list, current_time_sec: int, starting_flag: bool = True) -> list:
     """Get the IDs to display for the timer steps.
 
     Parameters
     ----------
-    steps              Steps obtained with 'get_build_order_timer_steps'.
-    current_time_sec   Current game time [sec].
+    steps               Steps obtained with 'get_build_order_timer_steps'.
+    current_time_sec    Current game time [sec].
+    starting_flag       True if the timer steps starts at the indicated time, False if ending at this time.
 
     Returns
     -------
     List of IDs of the steps to show, empty list if 'steps' is empty.
     """
-    if len(steps) == 0:
+    steps_count = len(steps)
+    if steps_count == 0:
         return []
 
-    selected_ids = [0]
     last_time_sec = -1
+    selected_ids = [0]  # showing first element if nothing else valid found
 
-    for step_id, step in enumerate(steps):  # loop on the steps
-        if step['time_sec'] <= current_time_sec:
+    # range of steps to analyze
+    step_range = range(steps_count)
+    if not starting_flag:  # going in reverse order when timing indicates finishing step
+        step_range = reversed(step_range)
+        selected_ids = [steps_count - 1]
+
+    for step_id in step_range:  # loop on the steps in ascending/descending order
+        step = steps[step_id]
+        if (starting_flag and (current_time_sec >= step['time_sec'])) or (
+                (not starting_flag) and (current_time_sec <= step['time_sec'])):
             if step['time_sec'] != last_time_sec:
                 selected_ids = [step_id]
                 last_time_sec = step['time_sec']
             else:
                 selected_ids.append(step_id)
         else:
-            return selected_ids
+            break
 
+    selected_ids.sort()
     return selected_ids
 
 

--- a/common/build_order_window.py
+++ b/common/build_order_window.py
@@ -16,11 +16,11 @@ from common.build_order_tools import check_valid_build_order_timer
 
 
 def open_website(website_link):
-    """Open the build order website
+    """Open the build order website.
 
     Parameters
     ----------
-    website_link    link to the website to open
+    website_link    Link to the website to open.
     """
     if website_link is not None:
         webbrowser.open(website_link)
@@ -36,16 +36,16 @@ class BuildOrderWindow(QMainWindow):
 
         Parameters
         ----------
-        app                          main application instance
-        parent                       the parent window
-        game_icon                    icon of the game
-        build_order_folder           folder where the build orders are saved
-        panel_settings               settings for the panel layout
-        edit_init_text               initial text for the build order text input
-        build_order_websites         list of website elements as [[button name 0, website link 0], [...]],
-                                     (each item contains these 2 elements)
-        directory_game_pictures      directory where the game pictures are located
-        directory_common_pictures    directory where the common pictures are located
+        app                          Main application instance.
+        parent                       The parent window.
+        game_icon                    Icon of the game.
+        build_order_folder           Folder where the build orders are saved.
+        panel_settings               Settings for the panel layout.
+        edit_init_text               Initial text for the build order text input.
+        build_order_websites         List of website elements as [[button name 0, website link 0], [...]],
+                                     (each item contains these 2 elements).
+        directory_game_pictures      Directory where the game pictures are located.
+        directory_common_pictures    Directory where the common pictures are located.
         """
         super().__init__()
 
@@ -269,7 +269,7 @@ class BuildOrderWindow(QMainWindow):
         self.show()
 
     def closeEvent(self, _):
-        """Called when clicking on the cross icon (closing window icon)"""
+        """Called when clicking on the cross icon (closing window icon)."""
         super().close()
 
     def add_button(self, label: str, click_function, pos_x: int, pos_y: int) -> QPushButton:
@@ -277,10 +277,10 @@ class BuildOrderWindow(QMainWindow):
 
         Parameters
         ----------
-        label             label of the button
-        click_function    function called when clicking on the button
-        pos_x             button position (X coordinate)
-        pos_y             button position (Y coordinate)
+        label             Label of the button.
+        click_function    Function called when clicking on the button.
+        pos_x             Button position (X coordinate).
+        pos_y             Button position (Y coordinate).
 
         Returns
         -------
@@ -421,7 +421,7 @@ class BuildOrderWindow(QMainWindow):
 
         Parameters
         ----------
-        name   name to copy
+        name   Name to copy.
         """
         name = name.replace('\\', '/')
         self.copy_line.setText(name)

--- a/common/build_order_window.py
+++ b/common/build_order_window.py
@@ -12,6 +12,7 @@ from PyQt5.QtCore import Qt, QSize
 from common.rts_overlay import RTSGameOverlay
 from common.rts_settings import RTSBuildOrderInputLayout
 from common.useful_tools import set_background_opacity, widget_x_end, widget_y_end, list_directory_files
+from common.build_order_tools import check_valid_build_order_timer
 
 
 def open_website(website_link):
@@ -361,7 +362,13 @@ class BuildOrderWindow(QMainWindow):
             valid_bo, bo_error_msg = self.parent.check_valid_build_order(self.build_order, bo_name_msg=False)
 
             if valid_bo:
-                self.check_valid_input.setText('Valid build order.')
+                if self.parent.build_order_timer['available']:
+                    if check_valid_build_order_timer(self.build_order):  # valid timing BO
+                        self.check_valid_input.setText('Valid build order (also valid for timing).')
+                    else:
+                        self.check_valid_input.setText('Valid build order (non-valid for timing).')
+                else:
+                    self.check_valid_input.setText('Valid build order.')
             else:
                 self.build_order = None
                 self.check_valid_input.setText('Invalid BO: ' + bo_error_msg)

--- a/common/build_order_window.py
+++ b/common/build_order_window.py
@@ -403,5 +403,5 @@ class BuildOrderWindow(QMainWindow):
 
     def add_build_order_step(self):
         """Add a step to the build order."""
-        self.build_order['build_order'].append(self.parent.get_build_order_step())
+        self.build_order['build_order'].append(self.parent.get_build_order_step(self.build_order['build_order']))
         self.format_build_order()

--- a/common/build_order_window.py
+++ b/common/build_order_window.py
@@ -121,16 +121,22 @@ class BuildOrderWindow(QMainWindow):
             'Reset build order', self.reset_build_order,
             self.border_size, self.max_y + self.vertical_spacing)
 
+        # button to display the build order
+        self.display_bo_button = self.add_button(
+            'Display', self.display_build_order,
+            widget_x_end(self.reset_bo_button) + self.horizontal_spacing, self.reset_bo_button.y())
+
         # button to add a new step
         self.add_step_button = self.add_button(
             'Add step', self.add_build_order_step,
-            widget_x_end(self.reset_bo_button) + self.horizontal_spacing, self.reset_bo_button.y())
+            widget_x_end(self.display_bo_button) + self.horizontal_spacing, self.display_bo_button.y())
         self.add_step_button.hide()
 
         # button to format the build order
         self.format_bo_button = self.add_button(
             'Format', self.format_build_order,
             widget_x_end(self.add_step_button) + self.horizontal_spacing, self.add_step_button.y())
+        self.max_width = max(self.max_width, widget_x_end(self.format_bo_button))
         self.format_bo_button.hide()
 
         # Check valid BO TXT input
@@ -344,6 +350,25 @@ class BuildOrderWindow(QMainWindow):
             self.format_bo_button.hide()
 
         self.check_valid_input.adjustSize()
+
+    def display_build_order(self):
+        """Display the current build order in the parent main window."""
+
+        if self.build_order is not None:
+            # show valid build order in main panel
+            self.parent.selected_build_order = self.build_order
+            self.parent.selected_build_order_step_count = len(self.parent.selected_build_order['build_order'])
+            self.parent.selected_build_order_step_id = self.parent.selected_build_order_step_count - 1
+            assert self.parent.selected_build_order_step_count > 0
+        else:
+            # show build order issue in main panel
+            self.parent.selected_build_order = {
+                'notes': [self.check_valid_input.text()]
+            }
+            self.parent.selected_build_order_step_count = 1
+            self.parent.selected_build_order_step_id = 0
+
+        self.parent.update_panel_elements()  # display in main panel
 
     def copy_icon_path(self, name: str):
         """Copy the path to the icon in clipboard and copy line.

--- a/common/build_order_window.py
+++ b/common/build_order_window.py
@@ -102,6 +102,7 @@ class BuildOrderWindow(QMainWindow):
         self.folder_button = self.add_button(
             'Open build orders folder', lambda: subprocess.run(['explorer', build_order_folder]),
             widget_x_end(self.update_button) + self.horizontal_spacing, self.update_button.y())
+        self.max_width = max(self.max_width, widget_x_end(self.folder_button))
 
         # button(s) to open build order website(s)
         self.website_buttons = []
@@ -115,6 +116,7 @@ class BuildOrderWindow(QMainWindow):
                     website_button_x, self.folder_button.y())
                 self.website_buttons.append(website_button)
                 website_button_x += website_button.width() + self.horizontal_spacing
+                self.max_width = max(self.max_width, widget_x_end(website_button))
 
         # button to reset the build order
         self.reset_bo_button = self.add_button(
@@ -386,6 +388,9 @@ class BuildOrderWindow(QMainWindow):
         try:
             if self.build_order is not None:
                 self.text_input.setText(json.dumps(self.build_order, indent=4))
+
+            # scroll bar to the end
+            self.text_input.verticalScrollBar().setValue(self.text_input.verticalScrollBar().maximum())
         except:
             print('Error when trying to format the build order')
 

--- a/common/build_order_window.py
+++ b/common/build_order_window.py
@@ -234,6 +234,8 @@ class BuildOrderWindow(QMainWindow):
         # window properties and show
         self.setWindowTitle('New build order')
         self.setWindowIcon(QIcon(game_icon))
+        if panel_settings.stay_on_top:
+            self.setWindowFlags(Qt.WindowStaysOnTopHint)  # window staying on top
         self.resize(self.max_width + self.border_size, self.max_y + self.border_size)
         set_background_opacity(self, self.color_background, self.opacity)
         self.show()

--- a/common/build_order_window.py
+++ b/common/build_order_window.py
@@ -133,11 +133,22 @@ class BuildOrderWindow(QMainWindow):
             'Add step', self.add_build_order_step,
             widget_x_end(self.display_bo_button) + self.horizontal_spacing, self.display_bo_button.y())
         self.add_step_button.hide()
+        last_button = self.add_step_button
+
+        # button to evaluate the time indications
+        if self.parent.evaluate_build_order_timing is not None:
+            self.evaluate_timing_button = self.add_button(
+                'Evaluate time', self.evaluate_build_order_timing,
+                widget_x_end(last_button) + self.horizontal_spacing, last_button.y())
+            self.evaluate_timing_button.hide()
+            last_button = self.evaluate_timing_button
+        else:
+            self.evaluate_timing_button = None
 
         # button to format the build order
         self.format_bo_button = self.add_button(
             'Format', self.format_build_order,
-            widget_x_end(self.add_step_button) + self.horizontal_spacing, self.add_step_button.y())
+            widget_x_end(last_button) + self.horizontal_spacing, last_button.y())
         self.max_width = max(self.max_width, widget_x_end(self.format_bo_button))
         self.format_bo_button.hide()
 
@@ -349,9 +360,13 @@ class BuildOrderWindow(QMainWindow):
         if self.build_order is not None:
             self.add_step_button.show()
             self.format_bo_button.show()
+            if self.evaluate_timing_button is not None:
+                self.evaluate_timing_button.show()
         else:
             self.add_step_button.hide()
             self.format_bo_button.hide()
+            if self.evaluate_timing_button is not None:
+                self.evaluate_timing_button.hide()
 
         self.check_valid_input.adjustSize()
 
@@ -405,3 +420,10 @@ class BuildOrderWindow(QMainWindow):
         """Add a step to the build order."""
         self.build_order['build_order'].append(self.parent.get_build_order_step(self.build_order['build_order']))
         self.format_build_order()
+
+    def evaluate_build_order_timing(self):
+        """Evaluate the time indications for the build order."""
+        if (self.parent.evaluate_build_order_timing is not None) and (self.build_order is not None):
+            self.parent.evaluate_build_order_timing(self.build_order)
+            self.format_build_order()
+            self.display_build_order()

--- a/common/hotkeys_window.py
+++ b/common/hotkeys_window.py
@@ -179,6 +179,8 @@ class HotkeysWindow(QMainWindow):
         # window properties and show
         self.setWindowTitle('Configure hotkeys')
         self.setWindowIcon(QIcon(game_icon))
+        if panel_settings.stay_on_top:
+            self.setWindowFlags(Qt.WindowStaysOnTopHint)  # window staying on top
         self.resize(max_width + self.border_size, widget_y_end(self.update_button) + self.border_size)
         set_background_opacity(self, self.color_background, self.opacity)
         self.show()

--- a/common/hotkeys_window.py
+++ b/common/hotkeys_window.py
@@ -62,6 +62,8 @@ class HotkeysWindow(QMainWindow):
                 'build_order_previous_step': 'Previous step / Timer -1 sec :',
                 'build_order_next_step': 'Next step / Timer +1 sec :',
                 'switch_timer_manual': 'Switch BO timer/manual :',
+                'start_timer': 'Start BO timer :',
+                'stop_timer': 'Stop BO timer :',
                 'start_stop_timer': 'Start/stop BO timer :',
                 'reset_timer': 'Reset BO timer :',
             }

--- a/common/hotkeys_window.py
+++ b/common/hotkeys_window.py
@@ -19,13 +19,13 @@ class HotkeysWindow(QMainWindow):
 
         Parameters
         ----------
-        parent             parent window
-        hotkeys            hotkeys current definition
-        game_icon          icon of the game
-        mouse_image        image for the mouse
-        settings_folder    folder with the settings file
-        panel_settings     settings for the panel layout
-        timer_flag         True to add the timer hotkeys
+        parent             Parent window.
+        hotkeys            Hotkeys current definition.
+        game_icon          Icon of the game.
+        mouse_image        Image for the mouse.
+        settings_folder    Folder with the settings file.
+        panel_settings     Settings for the panel layout.
+        timer_flag         True to add the timer hotkeys.
         """
         super().__init__()
         self.parent = parent
@@ -188,6 +188,6 @@ class HotkeysWindow(QMainWindow):
         self.show()
 
     def closeEvent(self, _):
-        """Called when clicking on the cross icon (closing window icon)"""
+        """Called when clicking on the cross icon (closing window icon)."""
         self.parent.keyboard_mouse.set_all_flags(False)
         super().close()

--- a/common/keyboard_mouse.py
+++ b/common/keyboard_mouse.py
@@ -4,15 +4,15 @@ from mouse import on_button
 
 
 class HotkeyFlagData:
-    """Flag for a hotkey, with related data (sequence and timestamp)"""
+    """Flag for a hotkey, with related data (sequence and timestamp)."""
 
     def __init__(self, flag: bool = False, sequence: str = ''):
         """Constructor
 
         Parameters
         ----------
-        flag        True if hotkey flag activated
-        sequence    sequence corresponding to the hotkey (keyboard or mouse)
+        flag        True if hotkey flag activated.
+        sequence    Sequence corresponding to the hotkey (keyboard or mouse).
         """
         self.sequence: str = sequence
         self.flag: bool = False
@@ -20,28 +20,28 @@ class HotkeyFlagData:
         self.set_flag(flag)
 
     def set_flag(self, flag: bool):
-        """Set the value for a flag and update the timestamp if flag set to True
+        """Set the value for a flag and update the timestamp if flag set to True.
 
         Parameters
         ----------
-        flag    True if hotkey flag activated
+        flag    True if hotkey flag activated.
         """
         self.flag = flag
         if flag:
             self.timestamp = time.time()
 
     def get_elapsed_time(self) -> float:
-        """Get the elapsed time since last timestamp
+        """Get the elapsed time since last timestamp.
 
         Returns
         -------
-        Elapsed time [s]
+        Elapsed time [s].
         """
         return time.time() - self.timestamp
 
 
 class KeyboardMouseManagement:
-    """Keyboard global hotkeys and mouse global buttons management"""
+    """Keyboard global hotkeys and mouse global buttons management."""
 
     def __init__(self, print_unset: bool = True):
         """Constructor
@@ -65,11 +65,11 @@ class KeyboardMouseManagement:
             on_button(self.set_mouse_flag, args=(mouse_button_name, True), buttons=mouse_button_name, types='up')
 
     def set_all_flags(self, value: bool):
-        """Set all the flags (keyboard and mouse) to the same value
+        """Set all the flags (keyboard and mouse) to the same value.
 
         Parameters
         ----------
-        value    value to set for the flags
+        value    Value to set for the flags.
         """
         for key in self.keyboard_hotkeys.keys():
             self.keyboard_hotkeys[key].set_flag(value)
@@ -82,12 +82,12 @@ class KeyboardMouseManagement:
 
         Parameters
         ----------
-        name        name of the keyboard hotkey
-        sequence    sequence for the keyboard 'add_hotkey' function, '' to ignore the hotkey
+        name        Name of the keyboard hotkey.
+        sequence    Sequence for the keyboard 'add_hotkey' function, '' to ignore the hotkey.
 
         Returns
         -------
-        True if hotkey created or updated
+        True if hotkey created or updated.
         """
         try:
             if name == '':  # safety on the hotkey name
@@ -132,8 +132,8 @@ class KeyboardMouseManagement:
 
         Parameters
         ----------
-        names    list of names for the keyboard hotkeys
-        value    new value for the keyboard hotkey flags
+        names    List of names for the keyboard hotkeys.
+        value    New value for the keyboard hotkey flags.
         """
         for name in names:  # loop on all the hotkey names
             if name in self.keyboard_hotkeys:
@@ -142,15 +142,15 @@ class KeyboardMouseManagement:
                 print(f'Unknown keyboard hotkey name received ({name}) to set the flag.')
 
     def is_keyboard_hotkey_pressed(self, name: str) -> bool:
-        """Check if a keyboard hotkey is pressed
+        """Check if a keyboard hotkey is pressed.
 
         Parameters
         ----------
-        name    name of the keyboard hotkey to look for
+        name    Name of the keyboard hotkey to look for.
 
         Returns
         -------
-        True if hotkey currently pressed, False if non-existent hotkey
+        True if hotkey currently pressed, False if non-existent hotkey.
         """
         if name in self.keyboard_hotkeys:
             return is_pressed(self.keyboard_hotkeys[name].sequence)
@@ -164,11 +164,11 @@ class KeyboardMouseManagement:
 
         Parameters
         ----------
-        name    name of the keyboard hotkey to look for
+        name    Name of the keyboard hotkey to look for.
 
         Returns
         -------
-        Flag value, False if non-existent hotkey
+        Flag value, False if non-existent hotkey.
         """
         if name in self.keyboard_hotkeys:
             flag_value = self.keyboard_hotkeys[name].flag
@@ -184,11 +184,11 @@ class KeyboardMouseManagement:
 
         Parameters
         ----------
-        name    name of the keyboard hotkey to look for
+        name    Name of the keyboard hotkey to look for.
 
         Returns
         -------
-        Elapsed_time, -1.0 if non-existent hotkey
+        Elapsed_time, -1.0 if non-existent hotkey.
         """
         if name in self.keyboard_hotkeys:
             return self.keyboard_hotkeys[name].get_elapsed_time()
@@ -202,8 +202,8 @@ class KeyboardMouseManagement:
 
         Parameters
         ----------
-        name     name of the mouse button
-        value    new value for the mouse flag
+        name     Name of the mouse button.
+        value    New value for the mouse flag.
         """
         if name in self.mouse_buttons:
             self.mouse_buttons[name].set_flag(value)
@@ -215,11 +215,11 @@ class KeyboardMouseManagement:
 
         Parameters
         ----------
-        name    name of the mouse button to look for
+        name    Name of the mouse button to look for.
 
         Returns
         -------
-        Flag value, False if non-existent mouse button
+        Flag value, False if non-existent mouse button.
         """
         if name in self.mouse_buttons:
             flag_value = self.mouse_buttons[name].flag
@@ -235,11 +235,11 @@ class KeyboardMouseManagement:
 
         Parameters
         ----------
-        name    name of the mouse button to look for
+        name    Name of the mouse button to look for.
 
         Returns
         -------
-        Elapsed_time, -1.0 if non-existent mouse button
+        Elapsed_time, -1.0 if non-existent mouse button.
         """
         if name in self.mouse_buttons:
             return self.mouse_buttons[name].get_elapsed_time()

--- a/common/label_display.py
+++ b/common/label_display.py
@@ -10,15 +10,15 @@ from common.useful_tools import widget_y_end
 
 
 def split_multi_label_line(line: str) -> list:
-    """Split a line based on the @ markers and remove first/last empty elements
+    """Split a line based on the @ markers and remove first/last empty elements.
 
     Parameters
     ----------
-    line    line to split
+    line    Line to split.
 
     Returns
     -------
-    requested split line
+    Requested split line.
     """
     split_line = line.split('@')
 
@@ -31,17 +31,17 @@ def split_multi_label_line(line: str) -> list:
 
 
 def is_mouse_in_label(mouse_x: int, mouse_y: int, label: QLabel) -> bool:
-    """Check if mouse position is inside a label ROI
+    """Check if mouse position is inside a label ROI.
 
     Parameters
     ----------
-    mouse_x    X position of the mouse (relative to window)
-    mouse_y    Y position of the mouse (relative to window)
-    label      label to check
+    mouse_x    X position of the mouse (relative to window).
+    mouse_y    Y position of the mouse (relative to window).
+    label      Label to check.
 
     Returns
     -------
-    True if inside the label
+    True if inside the label.
     """
     return (label.x() <= mouse_x <= label.x() + label.width()) and (
             label.y() <= mouse_y <= label.y() + label.height())
@@ -56,12 +56,12 @@ class QLabelSettings:
 
         Parameters
         ----------
-        text_color          color of the text [R, G, B], None for default
-        text_bold           True for bold text, False for normal text
-        text_alignment      text alignment: 'left', 'center' or 'right', None for default
-        background_color    color of the background [R, G, B], None for default
-        image_width         width to use for the image, None for default
-        image_height        height to use for the image, None for default
+        text_color          Color of the text [R, G, B], None for default.
+        text_bold           True for bold text, False for normal text.
+        text_alignment      Text alignment: 'left', 'center' or 'right', None for default.
+        background_color    Color of the background [R, G, B], None for default.
+        image_width         Width to use for the image, None for default.
+        image_height        Height to use for the image, None for default.
         """
         self.text_color = text_color
         self.text_bold = text_bold
@@ -82,10 +82,10 @@ class RectangleLimit:
 
         Parameters
         ----------
-        x         position in X of the first corner
-        y         position in Y of the first corner
-        width     rectangle width
-        height    rectangle height
+        x         Position in X of the first corner.
+        y         Position in Y of the first corner.
+        width     Rectangle width.
+        height    Rectangle height.
         """
         self.x = x
         self.y = y
@@ -111,16 +111,16 @@ class MultiQLabelDisplay:
 
         Parameters
         ----------
-        font_police               police to use for the font
-        font_size                 size of the font to use
-        border_size               size of the borders
-        vertical_spacing          vertical space between elements
-        color_default             default text RGB color for the font
-        color_row_emphasis        color for the (optional) row emphasis
-        image_height              height of the images, negative if no picture to use
-        extra_emphasis_height     extra pixels height for the color emphasis background rectangle
-        game_pictures_folder      folder where the game pictures are located, None if no game picture to use
-        common_pictures_folder    folder where the common pictures are located, None if no common picture to use
+        font_police               Police to use for the font.
+        font_size                 Size of the font to use.
+        border_size               Size of the borders.
+        vertical_spacing          Vertical space between elements.
+        color_default             Default text RGB color for the font.
+        color_row_emphasis        Color for the (optional) row emphasis.
+        image_height              Height of the images, negative if no picture to use.
+        extra_emphasis_height     Extra pixels height for the color emphasis background rectangle.
+        game_pictures_folder      Folder where the game pictures are located, None if no game picture to use.
+        common_pictures_folder    Folder where the common pictures are located, None if no common picture to use.
         """
         # font and images
         self.font_police = font_police
@@ -163,18 +163,18 @@ class MultiQLabelDisplay:
     def update_settings(self, font_police: str, font_size: int, border_size: int,
                         vertical_spacing: int, color_default: list, color_row_emphasis: list = (0, 0, 0),
                         image_height: int = -1, extra_emphasis_height=0):
-        """Update the settings
+        """Update the settings.
 
         Parameters
         ----------
-        font_police              police to use for the font
-        font_size                size of the font to use
-        border_size              size of the borders
-        vertical_spacing         vertical space between elements
-        color_default            default text RGB color for the font
-        color_row_emphasis       color for the (optional) row emphasis
-        image_height             height of the images, negative if no picture to use
-        extra_emphasis_height    extra pixels height for the color emphasis background rectangle
+        font_police              Police to use for the font.
+        font_size                Size of the font to use.
+        border_size              Size of the borders.
+        vertical_spacing         Vertical space between elements.
+        color_default            Default text RGB color for the font.
+        color_row_emphasis       Color for the (optional) row emphasis.
+        image_height             Height of the images, negative if no picture to use.
+        extra_emphasis_height    Extra pixels height for the color emphasis background rectangle.
         """
         self.clear()  # clear current content
 
@@ -207,11 +207,11 @@ class MultiQLabelDisplay:
         self.rows_roi_limits = []  # list of rows rectangular limits
 
     def x(self) -> int:
-        """Get X position of the first element
+        """Get X position of the first element.
 
         Returns
         -------
-        X position of the first element, 0 if no element
+        X position of the first element, 0 if no element.
         """
         if (len(self.labels) > 0) and (len(self.labels[0]) > 0):
             return self.labels[0][0].x()
@@ -219,11 +219,11 @@ class MultiQLabelDisplay:
             return 0
 
     def y(self) -> int:
-        """Get Y position of the first element
+        """Get Y position of the first element.
 
         Returns
         -------
-        Y position of the first element, 0 if no element
+        Y position of the first element, 0 if no element.
         """
         if (len(self.labels) > 0) and (len(self.labels[0]) > 0):
             return self.labels[0][0].y()
@@ -231,7 +231,7 @@ class MultiQLabelDisplay:
             return 0
 
     def show(self):
-        """Show all the labels"""
+        """Show all the labels."""
         if self.row_emphasis is not None:
             self.row_emphasis.show()
 
@@ -242,7 +242,7 @@ class MultiQLabelDisplay:
         self.shown = True
 
     def hide(self):
-        """Hide all the labels"""
+        """Hide all the labels."""
         if self.row_emphasis is not None:
             self.row_emphasis.hide()
 
@@ -253,11 +253,11 @@ class MultiQLabelDisplay:
         self.shown = False
 
     def is_visible(self) -> bool:
-        """Check if any element is visible
+        """Check if any element is visible.
 
         Returns
         -------
-        True if any element visible
+        True if any element visible.
         """
         if (self.row_emphasis is not None) and self.row_emphasis.isVisible():
             return True
@@ -270,7 +270,7 @@ class MultiQLabelDisplay:
         return False
 
     def clear(self):
-        """Hide and remove all labels"""
+        """Hide and remove all labels."""
         if self.row_emphasis is not None:
             self.row_emphasis.deleteLater()
         self.row_emphasis = None
@@ -286,12 +286,12 @@ class MultiQLabelDisplay:
         self.hide()
 
     def set_qlabel_settings(self, label: QLabel, settings: QLabelSettings = None):
-        """Adapt the settings (color, boldness...) of a QLabel
+        """Adapt the settings (color, boldness...) of a QLabel.
 
         Parameters
         ----------
-        label       QLabel to update
-        settings    settings of the QLabel, None for default
+        label       QLabel to update.
+        settings    Settings of the QLabel, None for default.
         """
         if settings is None:  # use default settings
             settings = QLabelSettings()
@@ -321,15 +321,15 @@ class MultiQLabelDisplay:
                 label.setAlignment(Qt.AlignRight)
 
     def get_image_path(self, image_search: str) -> Union[str, None]:
-        """Get the path for an image
+        """Get the path for an image.
 
         Parameters
         ----------
-        image_search    image to search
+        image_search    Image to search.
 
         Returns
         -------
-        image with its path, None if not found
+        Image with its path, None if not found.
         """
         if self.game_pictures_folder is not None:  # try first with the game folder
             game_image_path = os.path.join(self.game_pictures_folder, image_search)
@@ -350,11 +350,11 @@ class MultiQLabelDisplay:
 
         Parameters
         ----------
-        parent             parent element of this object
-        line               string text line with images between @ markers (e.g. 'text @image@ text')
-        labels_settings    settings for the QLabel elements, must be the same size as the line after splitting,
+        parent             Parent element of this object.
+        line               String text line with images between @ markers (e.g. 'text @image@ text').
+        labels_settings    Settings for the QLabel elements, must be the same size as the line after splitting,
                            see 'split_multi_label_line' function (None for default settings).
-        emphasis_flag      True to add background color emphasis on this row
+        emphasis_flag      True to add background color emphasis on this row.
         """
         if len(line) == 0:
             return
@@ -452,9 +452,9 @@ class MultiQLabelDisplay:
 
         Parameters
         ----------
-        parent    parent element of this object
-        height    height of the color rectangle
-        color     color of the rectangle
+        parent    Parent element of this object.
+        height    Height of the color rectangle.
+        color     Color of the rectangle.
         """
         assert len(color) == 3
 
@@ -470,15 +470,15 @@ class MultiQLabelDisplay:
 
     def update_size_position(self, init_x: int = -1, init_y: int = -1, panel_init_width: int = -1,
                              adapt_to_columns: int = -1):
-        """Update the size and position of all the labels
+        """Update the size and position of all the labels.
 
         Parameters
         ----------
-        init_x              initial X position of the first label, negative for border size
-        init_y              initial Y position of the first label, negative for border size
-        panel_init_width    initial width of the panel
-        adapt_to_columns    adapt the width to have columns for the X first columns
-                            (negative to ignore it, 0 to apply on the column count of the first row)
+        init_x              Initial X position of the first label, negative for border size.
+        init_y              Initial Y position of the first label, negative for border size.
+        panel_init_width    Initial width of the panel.
+        adapt_to_columns    Adapt the width to have columns for the X first columns
+                            (negative to ignore it, 0 to apply on the column count of the first row).
         """
 
         # adjust the size of the items
@@ -587,16 +587,16 @@ class MultiQLabelDisplay:
             self.row_emphasis.resize(panel_total_width, y1 - y0)
 
     def get_mouse_label_id(self, mouse_x: int, mouse_y: int) -> list:
-        """Get the IDs of the label hovered by the mouse
+        """Get the IDs of the label hovered by the mouse.
 
         Parameters
         ----------
-        mouse_x    mouse X position (inside the window)
-        mouse_y    mouse Y position (inside the window)
+        mouse_x    Mouse X position (inside the window).
+        mouse_y    Mouse Y position (inside the window).
 
         Returns
         -------
-        [row ID, column ID] of the label, [-1, -1] if not hovering any label
+        [row ID, column ID] of the label, [-1, -1] if not hovering any label.
         """
         for row_id, row in enumerate(self.labels):
             for column_id, label in enumerate(row):
@@ -605,13 +605,13 @@ class MultiQLabelDisplay:
         return [-1, -1]
 
     def set_color_label(self, row_id: int, column_id: int, color: list = None):
-        """Set the color of a label element
+        """Set the color of a label element.
 
         Parameters
         ----------
-        row_id       row ID of the label
-        column_id    column ID of the label
-        color        color to set, None to set the default color
+        row_id       Row ID of the label.
+        column_id    Column ID of the label.
+        color        Color to set, None to set the default color.
         """
         # check color
         if color is not None:

--- a/common/rts_overlay.py
+++ b/common/rts_overlay.py
@@ -1459,7 +1459,13 @@ class RTSGameOverlay(QMainWindow):
 
     def open_panel_add_build_order(self):
         """Open/close the panel to add a build order"""
-        pass  # will be re-implemented in daughter classes
+        self.build_order_tooltip.clear()  # clear tooltip
+
+        if self.selected_panel == PanelID.CONFIG:
+            self.save_upper_right_position()  # saving the upper right corner position
+            self.selected_panel = PanelID.BUILD_ORDER  # switch to build order panel
+            self.update_panel_elements()  # update the elements of the panel to display
+            self.update_position()  # restoring the upper right corner position
 
     def config_panel_layout(self):
         """Layout of the configuration panel"""

--- a/common/rts_overlay.py
+++ b/common/rts_overlay.py
@@ -1668,6 +1668,7 @@ class RTSGameOverlay(QMainWindow):
                 self.update_build_order_time_label()
             else:
                 self.update_build_order_step_label()
+            self.update_build_order()
             self.build_order_panel_layout()
 
     def update_build_order(self):

--- a/common/rts_overlay.py
+++ b/common/rts_overlay.py
@@ -14,10 +14,10 @@ from PyQt5.QtGui import QKeySequence, QFont, QIcon, QCursor
 from PyQt5.QtCore import Qt, QPoint, QSize
 
 from common.build_order_tools import get_build_orders, check_build_order_key_values, is_build_order_new, \
-    get_build_order_timer_steps, get_build_order_timer_step_ids
+    get_build_order_timer_steps, get_build_order_timer_step_ids, get_build_order_timer_steps_display
 from common.label_display import MultiQLabelDisplay, QLabelSettings
-from common.useful_tools import TwinHoverButton, scale_int, scale_list_int, set_background_opacity, widget_x_end, \
-    popup_message
+from common.useful_tools import TwinHoverButton, scale_int, scale_list_int, set_background_opacity, \
+    widget_x_end, widget_y_end, popup_message
 from common.keyboard_mouse import KeyboardMouseManagement
 from common.rts_settings import KeyboardMouse
 from common.hotkeys_window import HotkeysWindow
@@ -30,7 +30,7 @@ class PanelID(Enum):
 
 
 class RTSGameOverlay(QMainWindow):
-    """RTS game overlay application"""
+    """RTS game overlay application."""
 
     def __init__(self, app: QApplication, directory_main: str, name_game: str, settings_name: str, settings_class,
                  check_valid_build_order, get_build_order_step, get_build_order_template,
@@ -40,21 +40,21 @@ class RTSGameOverlay(QMainWindow):
 
         Parameters
         ----------
-        app                                     main application instance
-        directory_main                          directory where the main file is located
-        name_game                               name of the game (for pictures folder)
-        settings_name                           name of the settings (to load/save)
-        settings_class                          settings class
-        check_valid_build_order                 function to check if a build order is valid
-        get_build_order_step                    function to get one step of the build order
-        get_build_order_template                function to get the build order template
-        get_faction_selection                   function to get the faction selection dictionary
-        evaluate_build_order_timing             function to evaluate the build order time indications
-        build_order_category_name               if not None, accept build orders with same name,
-                                                provided they are in different categories
-        build_order_timer_available             True if the build order timer feature is available
+        app                                     Main application instance.
+        directory_main                          Directory where the main file is located.
+        name_game                               Name of the game (for pictures folder).
+        settings_name                           Name of the settings (to load/save).
+        settings_class                          Settings class.
+        check_valid_build_order                 Function to check if a build order is valid.
+        get_build_order_step                    Function to get one step of the build order.
+        get_build_order_template                Function to get the build order template.
+        get_faction_selection                   Function to get the faction selection dictionary.
+        evaluate_build_order_timing             Function to evaluate the build order time indications.
+        build_order_category_name               If not None, accept build orders with same name,
+                                                provided they are in different categories.
+        build_order_timer_available             True if the build order timer feature is available.
         build_order_timer_step_starting_flag    True if the timer steps starts at the requested time,
-                                                False if ending at this time
+                                                False if ending at this time.
         """
         super().__init__()
 
@@ -65,6 +65,8 @@ class RTSGameOverlay(QMainWindow):
         self.init_done = False
 
         self.selected_panel = PanelID.CONFIG  # panel to display
+
+        self.show_resources = True  # True to show the resources in the build order current display
 
         # directories
         self.name_game = name_game
@@ -312,6 +314,9 @@ class RTSGameOverlay(QMainWindow):
         # add build order
         self.panel_add_build_order = None
 
+        # create build orders folder
+        os.makedirs(self.directory_build_orders, exist_ok=True)
+
         # initialization done
         self.init_done = True
 
@@ -320,7 +325,7 @@ class RTSGameOverlay(QMainWindow):
 
         Parameters
         ----------
-        update_settings   True to update (reload) the settings, False to keep the current ones
+        update_settings   True to update (reload) the settings, False to keep the current ones.
         """
 
         # re-initialization not yet done
@@ -431,6 +436,8 @@ class RTSGameOverlay(QMainWindow):
             QIcon(os.path.join(self.directory_common_pictures, images.build_order_next_step)), action_button_qsize)
 
         # timer features
+        if self.build_order_switch_timer_manual is None:
+            self.settings.timer_available = False  # cannot be updated without relaunching the app
         if self.settings.timer_available:
             self.build_order_switch_timer_manual.update_icon_size(
                 QIcon(os.path.join(self.directory_common_pictures, images.switch_timer_manual)), action_button_qsize)
@@ -469,7 +476,7 @@ class RTSGameOverlay(QMainWindow):
 
         Parameters
         ----------
-        build_order_timer_flag   True to update BO with timer, False for manual selection
+        build_order_timer_flag   True to update BO with timer, False for manual selection.
         """
         self.build_order_timer['use_timer'] = build_order_timer_flag
         self.build_order_timer['run_timer'] = False
@@ -498,7 +505,7 @@ class RTSGameOverlay(QMainWindow):
             self.unscaled_settings.layout.upper_right_position[1] = screen_height - 40
 
     def set_keyboard_mouse(self):
-        """Set the keyboard and mouse hotkey inputs"""
+        """Set the keyboard and mouse hotkey inputs."""
 
         # selection keys
         hotkey_settings = self.unscaled_settings.hotkeys
@@ -540,7 +547,7 @@ class RTSGameOverlay(QMainWindow):
         self.keyboard_mouse.set_all_flags(False)
 
     def font_size_scaling_initialization(self):
-        """Font size and scaling combo initialization (common to constructor and reload)"""
+        """Font size and scaling combo initialization (common to constructor and reload)."""
         layout = self.unscaled_settings.layout
         color_default = layout.color_default
         color_default_str = f'color: rgb({color_default[0]}, {color_default[1]}, {color_default[2]})'
@@ -585,7 +592,7 @@ class RTSGameOverlay(QMainWindow):
         self.scaling_input.adjustSize()
 
     def configuration_initialization(self):
-        """Configuration elements initialization (common to constructor and reload)"""
+        """Configuration elements initialization (common to constructor and reload)."""
         layout = self.settings.layout
         color_default = layout.color_default
         color_default_str = f'color: rgb({color_default[0]}, {color_default[1]}, {color_default[2]})'
@@ -613,7 +620,7 @@ class RTSGameOverlay(QMainWindow):
         self.build_order_step_time.adjustSize()
 
     def window_color_position_initialization(self):
-        """Main window color and position initialization (common to constructor and reload)"""
+        """Main window color and position initialization (common to constructor and reload)."""
         layout = self.settings.layout
         color_background = layout.color_background
 
@@ -625,7 +632,7 @@ class RTSGameOverlay(QMainWindow):
         self.update_position()
 
     def settings_scaling(self):
-        """Apply the scaling on the settings"""
+        """Apply the scaling on the settings."""
         assert 0 <= self.scaling_input_selected_id < len(self.scaling_input_combo_ids)
         layout = self.settings.layout
         unscaled_layout = self.unscaled_settings.layout
@@ -673,7 +680,7 @@ class RTSGameOverlay(QMainWindow):
         panel_build_order.picture_size = scale_list_int(scaling, unscaled_panel_build_order.picture_size)
 
     def next_panel(self):
-        """Select the next panel"""
+        """Select the next panel."""
 
         # saving the upper right corner position
         if self.selected_panel == PanelID.CONFIG:
@@ -693,7 +700,7 @@ class RTSGameOverlay(QMainWindow):
         self.update_position()  # restoring the upper right corner position
 
     def update_panel_elements(self):
-        """Update the elements of the panel to display"""
+        """Update the elements of the panel to display."""
         if self.selected_panel != PanelID.CONFIG:
             QApplication.restoreOverrideCursor()
         else:
@@ -718,27 +725,27 @@ class RTSGameOverlay(QMainWindow):
         self.show()
 
     def mousePressEvent(self, event):
-        """Actions related to the mouse pressing events
+        """Actions related to the mouse pressing events.
 
         Parameters
         ----------
-        event    mouse event
+        event    Mouse event.
         """
         if self.selected_panel == PanelID.CONFIG:  # only needed when in configuration mode
             self.build_order_click_select(event)
 
     def mouseMoveEvent(self, event):
-        """Actions related to the mouse moving events
+        """Actions related to the mouse moving events.
 
         Parameters
         ----------
-        event    mouse event
+        event    Mouse event.
         """
         if self.selected_panel == PanelID.CONFIG:  # only needed when in configuration mode
             self.move_window(event)
 
     def quit_application(self):
-        """Quit the application"""
+        """Quit the application."""
         self.stop_application = True
         print('Stopping the application.')
 
@@ -771,11 +778,11 @@ class RTSGameOverlay(QMainWindow):
         QApplication.quit()
 
     def font_size_combo_box_change(self, value):
-        """Detect when the font size changed
+        """Detect when the font size changed.
 
         Parameters
         ----------
-        value    ID of the new font size in 'self.font_size_input_combo_ids'
+        value    ID of the new font size in 'self.font_size_input_combo_ids'.
         """
         if self.init_done and (0 <= value < len(self.font_size_input_combo_ids)):
             new_font = self.font_size_input_combo_ids[value]
@@ -793,11 +800,11 @@ class RTSGameOverlay(QMainWindow):
             self.reload(update_settings=False)
 
     def scaling_combo_box_change(self, value):
-        """Detect when the scaling changed
+        """Detect when the scaling changed.
 
         Parameters
         ----------
-        value    ID of the new scaling in 'self.scaling_input_combo_ids'
+        value    ID of the new scaling in 'self.scaling_input_combo_ids'.
         """
         if self.init_done and (0 <= value < len(self.scaling_input_combo_ids)):
             self.settings.layout.scaling = self.scaling_input_combo_ids[value]
@@ -806,7 +813,7 @@ class RTSGameOverlay(QMainWindow):
             self.reload(update_settings=False)
 
     def open_panel_configure_hotkeys(self):
-        """Open/close the panel to configure the hotkeys"""
+        """Open/close the panel to configure the hotkeys."""
         if (self.panel_config_hotkeys is not None) and self.panel_config_hotkeys.isVisible():  # close panel
             self.panel_config_hotkeys.close()
             self.panel_config_hotkeys = None
@@ -819,15 +826,15 @@ class RTSGameOverlay(QMainWindow):
                 timer_flag=self.build_order_timer['available'])
 
     def get_hotkey_mouse_flag(self, name: str) -> bool:
-        """Get the flag value for a global hotkey and/or mouse input
+        """Get the flag value for a global hotkey and/or mouse input.
 
         Parameters
         ----------
-        name    field to check
+        name    Field to check.
 
         Returns
         -------
-        True if flag activated, False if not activated or not found
+        True if flag activated, False if not activated or not found.
         """
         valid_keyboard = (name in self.keyboard_mouse.keyboard_hotkeys) and (
                 self.keyboard_mouse.keyboard_hotkeys[name].sequence != '')
@@ -964,7 +971,7 @@ class RTSGameOverlay(QMainWindow):
                         self.build_order_reset_timer.hovering_show(self.is_mouse_in_roi_widget)
 
     def show_hide(self):
-        """Show or hide the windows"""
+        """Show or hide the windows."""
         self.hidden = not self.hidden  # change the hidden state
 
         # adapt opacity
@@ -974,22 +981,22 @@ class RTSGameOverlay(QMainWindow):
             self.setWindowOpacity(self.settings.layout.opacity)
 
     def update_hotkeys(self):
-        """Update the hotkeys and the settings file"""
+        """Update the hotkeys and the settings file."""
         config_hotkeys = self.panel_config_hotkeys.hotkeys
         config_mouse_checkboxes = self.panel_config_hotkeys.mouse_checkboxes
         config_field_to_mouse = self.panel_config_hotkeys.field_to_mouse
 
         def split_keyboard_mouse(str_input: str):
-            """Split an input between keyboard and mouse parts
+            """Split an input between keyboard and mouse parts.
 
             Parameters
             ----------
-            str_input    input string from 'OverlaySequenceEdit'
+            str_input    Input string from 'OverlaySequenceEdit'.
 
             Returns
             -------
-            keyboard input, '' if no keyboard input
-            mouse input, '' if no valid mouse input
+            Keyboard input, '' if no keyboard input.
+            Mouse input, '' if no valid mouse input.
             """
             if '+' not in str_input:  # single input
                 if str_input in config_field_to_mouse:  # only mouse
@@ -1031,11 +1038,11 @@ class RTSGameOverlay(QMainWindow):
         self.save_settings()
 
     def add_build_order_json_data(self, build_order_data: dict) -> str:
-        """Add a build order, from its JSON format
+        """Add a build order, from its JSON format.
 
         Parameters
         ----------
-        build_order_data    build order data in JSON format
+        build_order_data    Build order data in JSON format.
 
         Returns
         -------
@@ -1088,7 +1095,7 @@ class RTSGameOverlay(QMainWindow):
         return msg_text
 
     def add_build_order(self):
-        """Try to add the build order written in the new build order panel"""
+        """Try to add the build order written in the new build order panel."""
         msg_text = None
         try:
             # get data as dictionary
@@ -1116,7 +1123,7 @@ class RTSGameOverlay(QMainWindow):
         popup_message('RTS Overlay - Adding new build order', msg_text)
 
     def save_settings(self):
-        """Save the settings"""
+        """Save the settings."""
         msg_text = f'Settings saved in {self.settings_file}.'  # message to display
         os.makedirs(os.path.dirname(self.settings_file), exist_ok=True)
         with open(self.settings_file, 'w') as f:
@@ -1127,56 +1134,56 @@ class RTSGameOverlay(QMainWindow):
         popup_message('RTS Overlay - Settings saved', msg_text)
 
     def update_mouse(self):
-        """Update the mouse position"""
+        """Update the mouse position."""
         pos = QCursor().pos()
         self.mouse_x = pos.x()
         self.mouse_y = pos.y()
 
     def is_mouse_in_roi(self, x: int, y: int, width: int, height: int) -> bool:
-        """Check if the last updated mouse position (using 'update_mouse') is in a ROI
+        """Check if the last updated mouse position (using 'update_mouse') is in a ROI.
 
         Parameters
         ----------
-        x         X position of the ROI (on the screen)
-        y         Y position of the ROI (on the screen)
-        width     width of the ROI
-        height    height of the ROI
+        x         X position of the ROI (on the screen).
+        y         Y position of the ROI (on the screen).
+        width     Width of the ROI.
+        height    Height of the ROI.
 
         Returns
         -------
-        True if in the ROI
+        True if in the ROI.
         """
         return (x <= self.mouse_x <= x + width) and (y <= self.mouse_y <= y + height)
 
     def is_mouse_in_window(self) -> bool:
-        """Checks if the mouse is in the current window
+        """Checks if the mouse is in the current window.
 
         Returns
         -------
-        True if mouse is in the window
+        True if mouse is in the window.
         """
         return self.is_mouse_in_roi(self.x(), self.y(), self.width(), self.height())
 
     def is_mouse_in_roi_widget(self, widget: QWidget) -> bool:
-        """Check if the last updated mouse position (using 'update_mouse') is in the ROI of a widget
+        """Check if the last updated mouse position (using 'update_mouse') is in the ROI of a widget.
 
         Parameters
         ----------
-        widget    widget to check
+        widget    Widget to check.
 
         Returns
         -------
-        True if mouse is in the ROI
+        True if mouse is in the ROI.
         """
         return self.is_mouse_in_roi(
             x=self.x() + widget.x(), y=self.y() + widget.y(), width=widget.width(), height=widget.height())
 
     def move_window(self, event):
-        """Move the window according to the mouse motion
+        """Move the window according to the mouse motion.
 
         Parameters
         ----------
-        event    mouse event
+        event    Mouse event.
         """
         QApplication.setOverrideCursor(Qt.ArrowCursor)  # set arrow cursor
 
@@ -1196,11 +1203,11 @@ class RTSGameOverlay(QMainWindow):
             self.unscaled_settings.layout.upper_right_position = [widget_x_end(self), self.y()]
 
     def build_order_click_select(self, event):
-        """Check if a build order is being clicked
+        """Check if a build order is being clicked.
 
         Parameters
         ----------
-        event    mouse event
+        event    Mouse event.
         """
         if event.buttons() == Qt.LeftButton:  # pressing the left button
             if len(self.valid_build_orders) >= 1:  # at least one build order
@@ -1213,15 +1220,15 @@ class RTSGameOverlay(QMainWindow):
                         print(f'Could not select build order with ID {build_order_ids[0]}.')
 
     def save_upper_right_position(self):
-        """Save of the upper right corner position"""
+        """Save of the upper right corner position."""
         self.upper_right_position = [widget_x_end(self), self.y()]
 
     def update_position(self):
-        """Update the position to stick to the saved upper right corner"""
+        """Update the position to stick to the saved upper right corner."""
         self.move(self.upper_right_position[0] - self.width(), self.upper_right_position[1])
 
     def build_order_previous_step(self):
-        """Select the previous step of the build order (or update to -1 sec for timer feature)"""
+        """Select the previous step of the build order (or update to -1 sec for timer feature)."""
         if self.selected_panel == PanelID.BUILD_ORDER:
 
             if self.build_order_timer['use_timer']:  # update timer
@@ -1237,7 +1244,7 @@ class RTSGameOverlay(QMainWindow):
                     self.update_build_order()  # update the rendering
 
     def build_order_next_step(self):
-        """Select the next step of the build order (or update to +1 sec for timer feature)"""
+        """Select the next step of the build order (or update to +1 sec for timer feature)."""
         if self.selected_panel == PanelID.BUILD_ORDER:
 
             if self.build_order_timer['use_timer']:  # update timer
@@ -1253,15 +1260,15 @@ class RTSGameOverlay(QMainWindow):
                     self.update_build_order()  # update the rendering
 
     def select_build_order_id(self, build_order_id: int = -1) -> bool:
-        """Select build order ID
+        """Select build order ID.
 
         Parameters
         ----------
-        build_order_id    ID of the build order, negative to select next build order
+        build_order_id    ID of the build order, negative to select next build order.
 
         Returns
         -------
-        True if valid build order selection
+        True if valid build order selection.
         """
         if len(self.valid_build_orders) >= 1:  # at least one build order
             if build_order_id >= 0:  # build order ID given
@@ -1277,11 +1284,11 @@ class RTSGameOverlay(QMainWindow):
         return False
 
     def get_valid_build_orders(self, key_condition: dict = None):
-        """Get the names of the valid build orders (with search bar)
+        """Get the names of the valid build orders (with search bar).
 
         Parameters
         ----------
-        key_condition   dictionary with the keys to look for and their value (to consider as valid), None to skip it
+        key_condition   Dictionary with the keys to look for and their value (to consider as valid), None to skip it.
         """
         self.valid_build_orders = []  # reset the list
         build_order_search_string = self.build_order_search.text()
@@ -1335,11 +1342,11 @@ class RTSGameOverlay(QMainWindow):
             self.build_order_selection_id = max(0, len(self.valid_build_orders) - 1)
 
     def obtain_build_order_search(self, key_condition: dict = None):
-        """Obtain the valid build order from search bar
+        """Obtain the valid build order from search bar.
 
         Parameters
         ----------
-        key_condition   dictionary with the keys to look for and their value (to consider as valid), None to skip it
+        key_condition   Dictionary with the keys to look for and their value (to consider as valid), None to skip it.
         """
         self.get_valid_build_orders(key_condition)
         valid_count = len(self.valid_build_orders)
@@ -1360,11 +1367,11 @@ class RTSGameOverlay(QMainWindow):
                 self.build_order_selection.add_row_from_picture_line(parent=self, line='no build order')
 
     def select_build_order(self, key_condition: dict = None):
-        """Select the requested valid build order
+        """Select the requested valid build order.
 
         Parameters
         ----------
-        key_condition   dictionary with the keys to look for and their value (to consider as valid), None to skip it
+        key_condition   Dictionary with the keys to look for and their value (to consider as valid), None to skip it.
         """
         self.build_order_selection.clear()
 
@@ -1410,7 +1417,7 @@ class RTSGameOverlay(QMainWindow):
         self.build_order_search.clearFocus()
 
     def hide_elements(self):
-        """Hide elements"""
+        """Hide elements."""
 
         # configuration buttons
         self.next_panel_button.hide()
@@ -1443,7 +1450,7 @@ class RTSGameOverlay(QMainWindow):
         self.build_order_notes.hide()
 
     def update_build_order_display(self):
-        """Update the build order search matching display"""
+        """Update the build order search matching display."""
         pass  # will be implemented in daughter classes
 
     def enter_key_actions(self):
@@ -1470,7 +1477,7 @@ class RTSGameOverlay(QMainWindow):
             self.update_panel_elements()  # update the elements of the panel to display
 
     def config_panel_layout(self):
-        """Layout of the configuration panel"""
+        """Layout of the configuration panel."""
         if self.selected_panel != PanelID.CONFIG:
             return
 
@@ -1514,8 +1521,115 @@ class RTSGameOverlay(QMainWindow):
         next_x += self.scaling_input.width() + horizontal_spacing
         self.next_panel_button.move(next_x, border_size)
 
+    def config_panel_layout_resize_move(self):
+        """Layout of the configuration panel (resizing and moving to correct location)."""
+        if self.selected_panel != PanelID.CONFIG:
+            return
+
+        border_size = self.settings.layout.border_size
+
+        max_x = max(self.next_panel_button.x_end(), widget_x_end(self.build_order_search),
+                    self.build_order_selection.x() + self.build_order_selection.row_max_width)
+
+        max_y = max(widget_y_end(self.build_order_search),
+                    self.build_order_selection.y() + self.build_order_selection.row_total_height)
+
+        # resize main window
+        self.resize(max_x + border_size, max_y + border_size)
+
+        # next panel on top right corner
+        self.next_panel_button.move(self.width() - border_size - self.next_panel_button.width(), border_size)
+
+        # update position (in case the size changed)
+        self.update_position()
+
+    def update_build_order(self):
+        """Update the build order panel."""
+        # clear the elements (also hide them)
+        self.build_order_resources.clear()
+        self.build_order_notes.clear()
+
+        if self.selected_build_order is None:  # no build order selected
+            self.build_order_notes.add_row_from_picture_line(parent=self, line='No build order selected.')
+
+        elif 'build_order' not in self.selected_build_order:  # only display notes
+            assert 'notes' in self.selected_build_order
+            for note in self.selected_build_order['notes']:
+                self.build_order_notes.add_row_from_picture_line(parent=self, line=note)
+
+        self.adapt_notes_to_columns = -1  # no column adaptation by default
+
+        # valid build order selected
+        if (self.selected_build_order is not None) and ('build_order' in self.selected_build_order):
+
+            # display selected step
+            if self.build_order_timer['use_timer']:
+                self.update_build_order_time_label()
+            else:
+                self.update_build_order_step_label()
+
+    def get_build_order_selected_steps_and_ids(self) -> (list, list):
+        """Get the build order timer steps to display.
+
+        Returns
+        -------
+        Step IDs of the output list (see below).
+        List of steps to display.
+        """
+
+        if self.build_order_timer['use_timer'] and self.build_order_timer['steps']:
+            # get steps to display
+            selected_steps_ids, selected_steps = get_build_order_timer_steps_display(
+                self.build_order_timer['steps'], self.build_order_timer['steps_ids'])
+        else:
+            selected_build_order_content = self.selected_build_order['build_order']
+
+            # select current step
+            assert 0 <= self.selected_build_order_step_id < self.selected_build_order_step_count
+            selected_steps_ids = [0]
+            selected_steps = [selected_build_order_content[self.selected_build_order_step_id]]
+            assert selected_steps[0] is not None
+        assert (len(selected_steps) > 0) and (len(selected_steps_ids) > 0)
+
+        return selected_steps, selected_steps_ids
+
+    def update_build_order_notes(self, selected_steps, selected_steps_ids):
+        """Update the notes of the build order.
+
+        Parameters
+        ----------
+        selected_steps        Step IDs of the output list (see below).
+        selected_steps_ids    List of steps to display.
+        """
+
+        layout = self.settings.layout
+        spacing = ' ' * layout.build_order.resource_spacing  # space between the elements
+
+        # line before notes
+        self.build_order_notes.add_row_color(
+            parent=self, height=layout.build_order.height_line_notes, color=layout.build_order.color_line_notes)
+
+        # loop on the steps for notes
+        for step_id, selected_step in enumerate(selected_steps):
+
+            # check if emphasis must be added on the corresponding note
+            emphasis_flag = self.build_order_timer['run_timer'] and (step_id in selected_steps_ids)
+
+            notes = selected_step['notes']
+            for note_id, note in enumerate(notes):
+                # add time if running timer and time available
+                line = ''
+                resource_step = selected_steps[selected_steps_ids[-1]]  # ID of the step to use to display the resources
+                if (self.build_order_timer['use_timer']) and ('time' in resource_step) and hasattr(
+                        layout.build_order, 'show_time_in_notes') and layout.build_order.show_time_in_notes:
+                    line += (str(selected_step['time']) if (note_id == 0) else ' ') + '@' + spacing + '@'
+                    self.adapt_notes_to_columns = 1
+                line += note
+                self.build_order_notes.add_row_from_picture_line(
+                    parent=self, line=line, emphasis_flag=emphasis_flag)
+
     def build_order_panel_layout(self):
-        """Layout of the Build order panel"""
+        """Layout of the Build order panel."""
         if self.selected_panel != PanelID.BUILD_ORDER:
             return
 
@@ -1532,14 +1646,49 @@ class RTSGameOverlay(QMainWindow):
         self.next_panel_button.show()
         self.build_order_notes.show()
 
-    def build_order_panel_layout_action_buttons(self):
-        """Layout of the Build order panel for the action buttons"""
+        # show elements
+        if self.show_resources:
+            self.build_order_resources.show()
+
+        # size and position
         layout = self.settings.layout
         border_size = layout.border_size
+        vertical_spacing = layout.vertical_spacing
         horizontal_spacing = layout.horizontal_spacing
         action_button_size = layout.action_button_size
         action_button_spacing = layout.action_button_spacing
         bo_next_tab_spacing = layout.build_order.bo_next_tab_spacing
+
+        # action buttons
+        next_y = border_size + action_button_size + vertical_spacing
+
+        if self.selected_build_order is not None:
+            self.build_order_step_time.adjustSize()
+            next_y = max(next_y, border_size + self.build_order_step_time.height() + vertical_spacing)
+
+        # build order resources
+        if self.show_resources:
+            self.build_order_resources.update_size_position(init_y=next_y)
+            next_y += self.build_order_resources.row_total_height + vertical_spacing
+
+        # maximum width
+        buttons_count = 3  # previous step + next step + next panel
+        if self.build_order_timer['available']:
+            buttons_count += 3 if self.build_order_timer[
+                'use_timer'] else 1  # switch timer-manual (+ start/stop + reset timer)
+        max_x = max(
+            (self.build_order_step_time.width() + buttons_count * action_button_size +
+             horizontal_spacing + (buttons_count - 2) * action_button_spacing + bo_next_tab_spacing),
+            self.build_order_resources.row_max_width)
+
+        # build order notes
+        self.build_order_notes.update_size_position(
+            init_y=next_y, panel_init_width=max_x + 2 * border_size,
+            adapt_to_columns=self.adapt_notes_to_columns)
+
+        # resize of the full window
+        max_x = max(max_x, self.build_order_notes.row_max_width)
+        self.resize(max_x + 2 * border_size, next_y + self.build_order_notes.row_total_height + border_size)
 
         # action buttons on top right corner
         next_x = self.width() - border_size - action_button_size
@@ -1566,6 +1715,9 @@ class RTSGameOverlay(QMainWindow):
             next_x -= (self.build_order_step_time.width() + horizontal_spacing)
 
             self.build_order_step_time.move(next_x, border_size)
+
+        # position update to stay with the same upper right corner position
+        self.update_position()
 
     def switch_build_order_timer_manual(self):
         """Switch the build order mode between timer and manual."""
@@ -1667,17 +1819,3 @@ class RTSGameOverlay(QMainWindow):
                 self.update_build_order_step_label()
             self.update_build_order()
             self.build_order_panel_layout()
-
-    def update_build_order(self):
-        """Update the build order panel"""
-        # clear the elements (also hide them)
-        self.build_order_resources.clear()
-        self.build_order_notes.clear()
-
-        if self.selected_build_order is None:  # no build order selected
-            self.build_order_notes.add_row_from_picture_line(parent=self, line='No build order selected.')
-
-        elif 'build_order' not in self.selected_build_order:  # only display notes
-            assert 'notes' in self.selected_build_order
-            for note in self.selected_build_order['notes']:
-                self.build_order_notes.add_row_from_picture_line(parent=self, line=note)

--- a/common/rts_overlay.py
+++ b/common/rts_overlay.py
@@ -1459,13 +1459,22 @@ class RTSGameOverlay(QMainWindow):
 
     def open_panel_add_build_order(self):
         """Open/close the panel to add a build order"""
-        self.build_order_tooltip.clear()  # clear tooltip
+        if (self.panel_add_build_order is None) or (not self.panel_add_build_order.isVisible()):  # open panel
 
-        if self.selected_panel == PanelID.CONFIG:
-            self.save_upper_right_position()  # saving the upper right corner position
-            self.selected_panel = PanelID.BUILD_ORDER  # switch to build order panel
+            # reset selected build order
+            self.selected_build_order = {
+                'notes': ['Update the build order in the \'New build order\' window.']
+            }
+            self.selected_build_order_name = None
+            self.selected_build_order_step_count = 0
+            self.selected_build_order_step_id = -1
+
+            if self.selected_panel == PanelID.CONFIG:
+                self.save_upper_right_position()  # saving the upper right corner position
+                self.selected_panel = PanelID.BUILD_ORDER  # switch to build order panel
+                self.update_position()  # restoring the upper right corner position
+
             self.update_panel_elements()  # update the elements of the panel to display
-            self.update_position()  # restoring the upper right corner position
 
     def config_panel_layout(self):
         """Layout of the configuration panel"""
@@ -1518,7 +1527,7 @@ class RTSGameOverlay(QMainWindow):
             return
 
         # show elements
-        if self.selected_build_order is not None:
+        if (self.selected_build_order is not None) and ('build_order' in self.selected_build_order):
             self.build_order_step_time.show()
             self.build_order_previous_button.show()
             self.build_order_next_button.show()
@@ -1663,4 +1672,14 @@ class RTSGameOverlay(QMainWindow):
 
     def update_build_order(self):
         """Update the build order panel"""
-        pass  # will be re-implemented in daughter classes
+        # clear the elements (also hide them)
+        self.build_order_resources.clear()
+        self.build_order_notes.clear()
+
+        if self.selected_build_order is None:  # no build order selected
+            self.build_order_notes.add_row_from_picture_line(parent=self, line='No build order selected.')
+
+        elif 'build_order' not in self.selected_build_order:  # only display notes
+            assert 'notes' in self.selected_build_order
+            for note in self.selected_build_order['notes']:
+                self.build_order_notes.add_row_from_picture_line(parent=self, line=note)

--- a/common/rts_overlay.py
+++ b/common/rts_overlay.py
@@ -35,24 +35,26 @@ class RTSGameOverlay(QMainWindow):
     def __init__(self, app: QApplication, directory_main: str, name_game: str, settings_name: str, settings_class,
                  check_valid_build_order, get_build_order_step, get_build_order_template,
                  get_faction_selection, evaluate_build_order_timing=None, build_order_category_name: str = None,
-                 build_order_timer_available: bool = False):
+                 build_order_timer_available: bool = True, build_order_timer_step_starting_flag: bool = True):
         """Constructor
 
         Parameters
         ----------
-        app                            main application instance
-        directory_main                 directory where the main file is located
-        name_game                      name of the game (for pictures folder)
-        settings_name                  name of the settings (to load/save)
-        settings_class                 settings class
-        check_valid_build_order        function to check if a build order is valid
-        get_build_order_step           function to get one step of the build order
-        get_build_order_template       function to get the build order template
-        get_faction_selection          function to get the faction selection dictionary
-        evaluate_build_order_timing    function to evaluate the build order time indications
-        build_order_category_name      if not None, accept build orders with same name,
-                                       provided they are in different categories
-        build_order_timer_available    True if the build order timer feature is available
+        app                                     main application instance
+        directory_main                          directory where the main file is located
+        name_game                               name of the game (for pictures folder)
+        settings_name                           name of the settings (to load/save)
+        settings_class                          settings class
+        check_valid_build_order                 function to check if a build order is valid
+        get_build_order_step                    function to get one step of the build order
+        get_build_order_template                function to get the build order template
+        get_faction_selection                   function to get the faction selection dictionary
+        evaluate_build_order_timing             function to evaluate the build order time indications
+        build_order_category_name               if not None, accept build orders with same name,
+                                                provided they are in different categories
+        build_order_timer_available             True if the build order timer feature is available
+        build_order_timer_step_starting_flag    True if the timer steps starts at the requested time,
+                                                False if ending at this time
         """
         super().__init__()
 
@@ -194,7 +196,10 @@ class RTSGameOverlay(QMainWindow):
         # build order timer elements
         self.build_order_timer: Dict[
             str, Union[bool, bool, bool, float, float, int, int, float, str, list, list, list, list]] = {
-            'available': build_order_timer_available,  # True if the build order timer feature is available
+            # True if the build order timer feature is available
+            'available': build_order_timer_available and self.settings.timer_available,
+            # True if the timer steps starts at the indicated time, False if ending at this time
+            'step_starting_flag': build_order_timer_step_starting_flag,
             'use_timer': False,  # True to update BO with timer, False for manual selection
             'run_timer': False,  # True if the BO timer is running (False to stop)
             'absolute_time_init': time.time(),  # last absolute time when the BO timer run started [sec]
@@ -862,7 +867,8 @@ class RTSGameOverlay(QMainWindow):
 
                     # compute current note ID
                     self.build_order_timer['steps_ids'] = get_build_order_timer_step_ids(
-                        self.build_order_timer['steps'], self.build_order_timer['time_int'])
+                        self.build_order_timer['steps'], self.build_order_timer['time_int'],
+                        self.build_order_timer['step_starting_flag'])
 
                     # note ID was updated
                     if self.build_order_timer['last_steps_ids'] != self.build_order_timer['steps_ids']:

--- a/common/rts_overlay.py
+++ b/common/rts_overlay.py
@@ -15,7 +15,7 @@ from PyQt5.QtCore import Qt, QPoint, QSize
 
 from common.build_order_tools import get_build_orders, check_build_order_key_values, is_build_order_new, \
     get_build_order_timer_steps, get_build_order_timer_step_ids
-from common.label_display import MultiQLabelDisplay, QLabelSettings, MultiQLabelWindow
+from common.label_display import MultiQLabelDisplay, QLabelSettings
 from common.useful_tools import TwinHoverButton, scale_int, scale_list_int, set_background_opacity, widget_x_end, \
     popup_message
 from common.keyboard_mouse import KeyboardMouseManagement
@@ -63,8 +63,6 @@ class RTSGameOverlay(QMainWindow):
         self.init_done = False
 
         self.selected_panel = PanelID.CONFIG  # panel to display
-
-        self.bo_tooltip_available = False  # no tooltip in build order by default
 
         # directories
         self.name_game = name_game
@@ -303,15 +301,6 @@ class RTSGameOverlay(QMainWindow):
         self.mouse_buttons_dict = dict()  # dictionary as {keyboard_name: mouse_button_name}
         self.set_keyboard_mouse()
 
-        # build order tooltip
-        layout = self.settings.layout
-        tooltip = layout.build_order_tooltip
-        self.build_order_tooltip = MultiQLabelWindow(
-            font_police=layout.font_police, font_size=layout.font_size, image_height=layout.build_order.image_height,
-            border_size=tooltip.border_size, vertical_spacing=tooltip.vertical_spacing,
-            color_default=tooltip.color_default, color_background=tooltip.color_background, opacity=tooltip.opacity,
-            game_pictures_folder=self.directory_game_pictures, common_pictures_folder=self.directory_common_pictures)
-
         # configure hotkeys
         self.panel_config_hotkeys = None
 
@@ -448,14 +437,6 @@ class RTSGameOverlay(QMainWindow):
 
         # keyboard and mouse global hotkeys
         self.set_keyboard_mouse()
-
-        # build order tooltip
-        layout = self.settings.layout
-        tooltip = layout.build_order_tooltip
-        self.build_order_tooltip.update_settings(
-            font_police=layout.font_police, font_size=layout.font_size, image_height=layout.build_order.image_height,
-            border_size=tooltip.border_size, vertical_spacing=tooltip.vertical_spacing,
-            color_default=tooltip.color_default, color_background=tooltip.color_background, opacity=tooltip.opacity)
 
         # open popup message
         if update_settings:
@@ -689,9 +670,6 @@ class RTSGameOverlay(QMainWindow):
     def next_panel(self):
         """Select the next panel"""
 
-        # clear tooltip
-        self.build_order_tooltip.clear()
-
         # saving the upper right corner position
         if self.selected_panel == PanelID.CONFIG:
             self.save_upper_right_position()
@@ -784,7 +762,6 @@ class RTSGameOverlay(QMainWindow):
             self.panel_add_build_order.close()
             self.panel_add_build_order = None
 
-        self.build_order_tooltip.close()
         self.close()
         QApplication.quit()
 
@@ -977,17 +954,6 @@ class RTSGameOverlay(QMainWindow):
                     if self.build_order_timer['use_timer']:
                         self.build_order_start_stop_timer.hovering_show(self.is_mouse_in_roi_widget)
                         self.build_order_reset_timer.hovering_show(self.is_mouse_in_roi_widget)
-
-        # tooltip display
-        if self.bo_tooltip_available and self.is_mouse_in_window():
-            if self.selected_panel == PanelID.BUILD_ORDER:  # build order specific buttons
-                if not self.build_order_tooltip.is_visible():  # no build order tooltip still active
-                    tooltip, label_x, label_y = self.build_order_resources.get_hover_tooltip(
-                        0, self.mouse_x - self.x(), self.mouse_y - self.y())
-                    if tooltip is not None:  # valid tooltip to display
-                        self.build_order_tooltip.display_dictionary(
-                            tooltip, self.x() + label_x, self.y() + label_y,
-                            self.settings.layout.build_order.tooltip_timeout)
 
     def show_hide(self):
         """Show or hide the windows"""
@@ -1249,7 +1215,6 @@ class RTSGameOverlay(QMainWindow):
     def build_order_previous_step(self):
         """Select the previous step of the build order (or update to -1 sec for timer feature)"""
         if self.selected_panel == PanelID.BUILD_ORDER:
-            self.build_order_tooltip.clear()  # clear tooltip
 
             if self.build_order_timer['use_timer']:  # update timer
                 self.build_order_timer['time_sec'] -= 1.0
@@ -1266,7 +1231,6 @@ class RTSGameOverlay(QMainWindow):
     def build_order_next_step(self):
         """Select the next step of the build order (or update to +1 sec for timer feature)"""
         if self.selected_panel == PanelID.BUILD_ORDER:
-            self.build_order_tooltip.clear()  # clear tooltip
 
             if self.build_order_timer['use_timer']:  # update timer
                 self.build_order_timer['time_sec'] += 1.0

--- a/common/rts_overlay.py
+++ b/common/rts_overlay.py
@@ -854,6 +854,8 @@ class RTSGameOverlay(QMainWindow):
         """Function called on a timer for build order timer update."""
         if self.build_order_timer['run_timer']:
             elapsed_time = time.time() - self.build_order_timer['absolute_time_init']
+            if hasattr(self.settings, 'timer_speed_factor'):  # in case timer value is not the same as real-time
+                elapsed_time *= self.settings.timer_speed_factor
             self.build_order_timer['time_sec'] = self.build_order_timer['time_sec_init'] + elapsed_time
             self.build_order_timer['time_int'] = int(floor(self.build_order_timer['time_sec']))
 

--- a/common/rts_overlay.py
+++ b/common/rts_overlay.py
@@ -34,7 +34,7 @@ class RTSGameOverlay(QMainWindow):
 
     def __init__(self, app: QApplication, directory_main: str, name_game: str, settings_name: str, settings_class,
                  check_valid_build_order, get_build_order_step, get_build_order_template,
-                 get_faction_selection, build_order_category_name: str = None,
+                 get_faction_selection, evaluate_build_order_timing=None, build_order_category_name: str = None,
                  build_order_timer_available: bool = False):
         """Constructor
 
@@ -49,6 +49,7 @@ class RTSGameOverlay(QMainWindow):
         get_build_order_step           function to get one step of the build order
         get_build_order_template       function to get the build order template
         get_faction_selection          function to get the faction selection dictionary
+        evaluate_build_order_timing    function to evaluate the build order time indications
         build_order_category_name      if not None, accept build orders with same name,
                                        provided they are in different categories
         build_order_timer_available    True if the build order timer feature is available
@@ -150,6 +151,7 @@ class RTSGameOverlay(QMainWindow):
         self.get_build_order_step = get_build_order_step
         self.get_build_order_template = get_build_order_template
         self.get_faction_selection = get_faction_selection
+        self.evaluate_build_order_timing = evaluate_build_order_timing
         self.build_order_category_name = build_order_category_name
         self.build_orders = get_build_orders(self.directory_build_orders, check_valid_build_order,
                                              category_name=self.build_order_category_name)

--- a/common/rts_settings.py
+++ b/common/rts_settings.py
@@ -148,6 +148,8 @@ class RTSBuildOrderInputLayout(SettingsSubclass):
         self.combo_extra_width: int = 10  # extra width for the combo selection size
         self.copy_line_width: int = 600  # width for the line to copy
         self.copy_line_height: int = 30  # height for the line to copy
+        self.timing_offset_max_length: int = 4  # maximum length for the timing offset input (- sign included)
+        self.timing_offset_width: int = 40  # width for the timing offset input
         self.pictures_column_max_count: int = 12  # maximum number of columns for the pictures
         self.picture_size: list = [40, 40]  # size for the pictures selection icons
 

--- a/common/rts_settings.py
+++ b/common/rts_settings.py
@@ -58,6 +58,7 @@ class RTSLayout(SettingsSubclass):
         self.color_background: list = [30, 30, 30]  # background RGB color
         self.action_button_size: int = 22  # size of the action buttons
         self.action_button_spacing: int = 8  # horizontal spacing between the action buttons
+        self.show_time_resource: bool = True  # True to show the time in the resource panel
 
 
 class RTSImages(SettingsSubclass):

--- a/common/rts_settings.py
+++ b/common/rts_settings.py
@@ -26,7 +26,6 @@ class RTSBuildOrderLayout(SettingsSubclass):
         self.image_height: int = 30  # height of the build order images
         self.resource_spacing: int = 3  # space between the build order resources
         self.bo_next_tab_spacing: int = 30  # horizontal spacing between build order last button and next tab button
-        self.tooltip_timeout: int = 1500  # timeout after which the tooltip is removed [ms]
         self.height_line_notes: int = 3  # height of the line before the notes
         self.color_line_notes: list = [168, 177, 183]  # color of the line before the notes
 
@@ -40,19 +39,6 @@ class RTSBuildOrderTimerLayout(RTSBuildOrderLayout):
         self.show_time_in_notes: bool = True  # True to show the time indication next to the notes (in timer mode)
         self.color_row_emphasis: list = [0, 51, 102]  # color to use for the emphasis background rectangle
         self.extra_emphasis_height: int = 3  # extra pixels height for the color emphasis background rectangle
-
-
-class RTSBuildOrderTooltipLayout(SettingsSubclass):
-    """Settings for the RTS build order layout (tooltip part)"""
-
-    def __init__(self):
-        """Constructor"""
-        self.color_default: list = [255, 255, 255]  # default text RGB color for the font
-        self.color_background: list = [0, 0, 0]  # background RGB color of the tooltip window
-        self.opacity: float = 0.8  # opacity of the tooltip window
-        self.vertical_spacing: int = 2  # vertical spacing for the tooltip lines
-        self.border_size: int = 5  # border size of the tooltip window
-        self.timeout: int = 1500  # time after which the tooltip is removed [ms]
 
 
 class RTSLayout(SettingsSubclass):
@@ -72,7 +58,6 @@ class RTSLayout(SettingsSubclass):
         self.color_background: list = [30, 30, 30]  # background RGB color
         self.action_button_size: int = 22  # size of the action buttons
         self.action_button_spacing: int = 8  # horizontal spacing between the action buttons
-        self.build_order_tooltip: RTSBuildOrderTooltipLayout = RTSBuildOrderTooltipLayout()  # build order tooltip
 
 
 class RTSImages(SettingsSubclass):

--- a/common/rts_settings.py
+++ b/common/rts_settings.py
@@ -126,8 +126,8 @@ class RTSBuildOrderInputLayout(SettingsSubclass):
         self.color_background: list = [30, 30, 30]  # color of the background
         self.opacity: float = 0.8  # opacity of the window
         self.border_size: int = 10  # size of the borders
-        self.edit_width: int = 1000  # width for the build order text input
-        self.edit_height: int = 500  # height for the build order text input
+        self.edit_width: int = 800  # width for the build order text input
+        self.edit_height: int = 400  # height for the build order text input
         self.button_margin: int = 5  # margin from text to button border
         self.vertical_spacing: int = 10  # vertical spacing between the elements
         self.horizontal_spacing: int = 10  # horizontal spacing between the elements

--- a/common/rts_settings.py
+++ b/common/rts_settings.py
@@ -126,8 +126,8 @@ class RTSBuildOrderInputLayout(SettingsSubclass):
         self.color_background: list = [30, 30, 30]  # color of the background
         self.opacity: float = 0.8  # opacity of the window
         self.border_size: int = 10  # size of the borders
-        self.edit_width: int = 800  # width for the build order text input
-        self.edit_height: int = 400  # height for the build order text input
+        self.edit_width: int = 1000  # width for the build order text input
+        self.edit_height: int = 500  # height for the build order text input
         self.button_margin: int = 5  # margin from text to button border
         self.vertical_spacing: int = 10  # vertical spacing between the elements
         self.horizontal_spacing: int = 10  # horizontal spacing between the elements

--- a/common/rts_settings.py
+++ b/common/rts_settings.py
@@ -111,7 +111,7 @@ class RTSHotkeysConfigurationLayout(SettingsSubclass):
 
     def __init__(self):
         """Constructor"""
-        self.stay_on_top: bool = True  # True to always stay on top of other windows
+        self.stay_on_top: bool = False  # True to always stay on top of other windows
         self.font_police: str = 'Arial'  # font police type
         self.font_size: int = 11  # font size
         self.color_font: list = [255, 255, 255]  # color of the font
@@ -185,6 +185,8 @@ class RTSTimerHotkeys(RTSHotkeys):
         """Constructor"""
         super().__init__()
         self.switch_timer_manual: KeyboardMouse = KeyboardMouse()  # switch build order between timer/manual
+        self.start_timer: KeyboardMouse = KeyboardMouse()  # start the build order timer
+        self.stop_timer: KeyboardMouse = KeyboardMouse()  # stop the build order timer
         self.start_stop_timer: KeyboardMouse = KeyboardMouse()  # start/stop the build order timer
         self.reset_timer: KeyboardMouse = KeyboardMouse()  # reset the build order timer
 

--- a/common/rts_settings.py
+++ b/common/rts_settings.py
@@ -111,6 +111,7 @@ class RTSHotkeysConfigurationLayout(SettingsSubclass):
 
     def __init__(self):
         """Constructor"""
+        self.stay_on_top: bool = True  # True to always stay on top of other windows
         self.font_police: str = 'Arial'  # font police type
         self.font_size: int = 11  # font size
         self.color_font: list = [255, 255, 255]  # color of the font
@@ -132,6 +133,7 @@ class RTSBuildOrderInputLayout(SettingsSubclass):
 
     def __init__(self):
         """Constructor"""
+        self.stay_on_top: bool = True  # True to always stay on top of other windows
         self.font_police: str = 'Arial'  # font police type
         self.font_size: int = 11  # font size
         self.color_font: list = [255, 255, 255]  # color of the font

--- a/common/rts_settings.py
+++ b/common/rts_settings.py
@@ -181,7 +181,7 @@ class RTSOverlaySettings(SettingsSubclass):
 
     def __init__(self):
         """Constructor"""
-        self.timer_available: bool = False  # True if timer feature available
+        self.timer_available: bool = True  # True if timer feature available
 
         self.call_ms: int = 20  # interval between 2 calls (e.g. for mouse motion) [ms]
 

--- a/common/settings_subclass.py
+++ b/common/settings_subclass.py
@@ -2,11 +2,11 @@ class SettingsSubclass:
     """Settings for a subclass"""
 
     def to_dict(self) -> dict:
-        """Convert content to dictionary
+        """Convert content to dictionary.
 
         Returns
         -------
-        dictionary data
+        Dictionary data.
         """
         data = self.__dict__.copy()
         for key in data:
@@ -15,11 +15,11 @@ class SettingsSubclass:
         return data
 
     def from_dict(self, data):
-        """Update content from dictionary
+        """Update content from dictionary.
 
         Parameters
         ----------
-        data    dictionary data
+        data    Dictionary data.
         """
         for key in self.__dict__:
             if key in data:

--- a/common/useful_tools.py
+++ b/common/useful_tools.py
@@ -361,4 +361,5 @@ def popup_message(title: str, msg_text: str):
     msg.setWindowTitle(title)
     msg.setText(msg_text)
     msg.setIcon(QMessageBox.Information)
+    msg.setWindowFlags(Qt.WindowStaysOnTopHint)  # window staying on top
     msg.exec_()

--- a/common/useful_tools.py
+++ b/common/useful_tools.py
@@ -7,58 +7,58 @@ from PyQt5.QtCore import Qt, QSize
 
 
 def widget_x_end(widget: QWidget) -> int:
-    """Get the end position of a widget, along its X axis
+    """Get the end position of a widget, along its X axis.
 
     Parameters
     ----------
-    widget    widget to measure
+    widget    Widget to measure.
 
     Returns
     -------
-    end position of a widget, along its X axis
+    End position of a widget, along its X axis.
     """
     return widget.x() + widget.width()
 
 
 def widget_y_end(widget: QWidget) -> int:
-    """Get the end position of a widget, along its Y axis
+    """Get the end position of a widget, along its Y axis.
 
     Parameters
     ----------
-    widget    widget to measure
+    widget    Widget to measure.
 
     Returns
     -------
-    end position of a widget, along its Y axis
+    End position of a widget, along its Y axis.
     """
     return widget.y() + widget.height()
 
 
 def list_directory_files(directory: str, extension: Union[str, list] = None, recursive: bool = True) -> list:
-    """List files in directory
+    """List files in directory.
 
     Parameters
     ----------
-    directory    directory to check
-    extension    extension of the files to look for (or list of valid extensions) with dot,
-                 None if not relevant
-    recursive    True if recursive search, False for search only at the root
+    directory    Directory to check.
+    extension    Extension of the files to look for (or list of valid extensions) with dot,
+                 None if not relevant.
+    recursive    True if recursive search, False for search only at the root.
 
     Returns
     -------
-    list of requested files
+    List of requested files.
     """
 
     def is_valid_extension(file):
-        """Check if extension is valid
+        """Check if extension is valid.
 
         Parameters
         ----------
-        file    file to check
+        file    File to check.
 
         Returns
         -------
-        True if valid extension
+        True if valid extension.
         """
         if extension is None:  # no extension request
             return True
@@ -88,16 +88,16 @@ def list_directory_files(directory: str, extension: Union[str, list] = None, rec
 
 
 def cut_name_length(name: str, max_length: int) -> str:
-    """Cut a name to a maximum length (and remove starting and ending spaces)
+    """Cut a name to a maximum length (and remove starting and ending spaces).
 
     Parameters
     ----------
-    name          name to cut
-    max_length    maximum length of the name (number of characters)
+    name          Name to cut.
+    max_length    Maximum length of the name (number of characters).
 
     Returns
     -------
-    Name with correct size, space removed (and dot added if needed)
+    Name with correct size, space removed (and dot added if needed).
     """
     name = name.strip()  # remove spaces
     if len(name) <= max_length:
@@ -107,31 +107,31 @@ def cut_name_length(name: str, max_length: int) -> str:
 
 
 def scale_int(scaling: float, value: int) -> int:
-    """Scaling an integer
+    """Scaling an integer.
 
     Parameters
     ----------
-    scaling    scaling factor
-    value      integer to scale
+    scaling    Scaling factor.
+    value      Integer to scale.
 
     Returns
     -------
-    scaled integer
+    Scaled integer.
     """
     return int(round(scaling * value))
 
 
 def scale_list_int(scaling: float, in_list: list) -> list:
-    """Scaling a list of integers
+    """Scaling a list of integers.
 
     Parameters
     ----------
-    scaling    scaling factor
-    in_list    input list of integers to scale
+    scaling    Scaling factor.
+    in_list    Input list of integers to scale.
 
     Returns
     -------
-    output list corresponding to the input list scaled
+    Output list corresponding to the input list scaled.
     """
     out_list = []
     for i in range(len(in_list)):
@@ -148,12 +148,12 @@ class TwinHoverButton:
 
         Parameters
         ----------
-        parent                parent window of the main button
-        icon                  icon of the button
-        button_qsize          size of the button
-        click_connect         function to activate when clicking on the button, None to skip it
-        click_connect_args    arguments for 'click_connect', None if no argument
-        tooltip               tooltip to display, None for no tooltip
+        parent                Parent window of the main button.
+        icon                  Icon of the button.
+        button_qsize          Size of the button.
+        click_connect         Function to activate when clicking on the button, None to skip it.
+        click_connect_args    Arguments for 'click_connect', None if no argument.
+        tooltip               Tooltip to display, None for no tooltip.
         """
         # main button
         self.parent = parent
@@ -173,12 +173,12 @@ class TwinHoverButton:
         self.update_tooltip(tooltip=tooltip)
 
     def update_icon_size(self, icon: QIcon, button_qsize: QSize):
-        """Update the icon and the size of both buttons
+        """Update the icon and the size of both buttons.
 
         Parameters
         ----------
-        icon            icon of the button
-        button_qsize    size of the button
+        icon            Icon of the button.
+        button_qsize    Size of the button.
         """
         self.button.setIcon(icon)
         self.button.setIconSize(button_qsize)
@@ -189,12 +189,12 @@ class TwinHoverButton:
         self.hovering_button.resize(button_qsize)
 
     def update_click_connect(self, click_connect, click_connect_args):
-        """Update the function to activate when clicking on the button
+        """Update the function to activate when clicking on the button.
 
         Parameters
         ----------
-        click_connect         function to activate when clicking on the button, None to not skip it
-        click_connect_args    arguments for 'click_connect', None if no argument
+        click_connect         Function to activate when clicking on the button, None to not skip it.
+        click_connect_args    Arguments for 'click_connect', None if no argument.
         """
         if click_connect is not None:
             if click_connect_args is None:  # no argument provided
@@ -205,74 +205,74 @@ class TwinHoverButton:
                 self.hovering_button.clicked.connect(lambda: click_connect(click_connect_args))
 
     def update_tooltip(self, tooltip: str = None):
-        """Update the buttons tooltip
+        """Update the buttons tooltip.
 
         Parameters
         ----------
-        tooltip    tooltip to display, None for no tooltip
+        tooltip    Tooltip to display, None for no tooltip.
         """
         if tooltip is not None:
             self.button.setToolTip(tooltip)
             self.hovering_button.setToolTip(tooltip)
 
     def show(self):
-        """Show the main button"""
+        """Show the main button."""
         self.button.show()
 
     def hide(self):
-        """Hide both buttons"""
+        """Hide both buttons."""
         self.button.hide()
         self.hovering_button.hide()
 
     def close(self):
-        """Close both buttons"""
+        """Close both buttons."""
         self.button.close()
         self.hovering_button.close()
 
     def move(self, x, y):
-        """Move the main button
+        """Move the main button.
 
         Parameters
         ----------
-        x    X position
-        y    Y position
+        x    X position.
+        y    Y position.
         """
         self.button.move(x, y)
 
     def x(self) -> int:
-        """Get the X position of the main button"""
+        """Get the X position of the main button."""
         return self.button.x()
 
     def y(self) -> int:
-        """Get the Y position of the main button"""
+        """Get the Y position of the main button."""
         return self.button.y()
 
     def x_end(self) -> int:
-        """Get the X end position of the main button"""
+        """Get the X end position of the main button."""
         return widget_x_end(self.button)
 
     def y_end(self) -> int:
-        """Get the Y end position of the main button"""
+        """Get the Y end position of the main button."""
         return widget_y_end(self.button)
 
     def width(self) -> int:
-        """Get the width of the main button"""
+        """Get the width of the main button."""
         return self.button.width()
 
     def height(self) -> int:
-        """Get the height of the main button"""
+        """Get the height of the main button."""
         return self.button.height()
 
     def raise_(self):
-        """Raise to the top of the parent widget's stack"""
+        """Raise to the top of the parent widget's stack."""
         self.button.raise_()
 
     def hovering_show(self, is_mouse_in_roi_widget):
-        """Detect if the twin hovering button must be shown, and update it accordingly
+        """Detect if the twin hovering button must be shown, and update it accordingly.
 
         Parameters
         ----------
-        is_mouse_in_roi_widget    function to check if hovering on the button
+        is_mouse_in_roi_widget    Function to check if hovering on the button.
         """
         # only when button is visible
         if self.button.isVisible():
@@ -284,13 +284,13 @@ class TwinHoverButton:
 
 
 def set_background_opacity(window, color_background: list, opacity: float):
-    """Set the background color and opacity of a window
+    """Set the background color and opacity of a window.
 
     Parameters
     ----------
-    window              window to update
-    color_background    color of the background for the window
-    opacity             opacity of the window
+    window              Window to update.
+    color_background    Color of the background for the window.
+    opacity             Opacity of the window.
     """
     assert len(color_background) == 3
     window.setStyleSheet(
@@ -306,16 +306,16 @@ class OverlaySequenceEdit(QKeySequenceEdit):
 
         Parameters
         ----------
-        parent    parent window
+        parent    Parent window.
         """
         super().__init__(parent)
 
     def keyPressEvent(self, QKeyEvent):
-        """Handle key input
+        """Handle key input.
 
         Parameters
         ----------
-        QKeyEvent    key event
+        QKeyEvent    Key event.
         """
         super().keyPressEvent(QKeyEvent)
 
@@ -330,11 +330,11 @@ class OverlaySequenceEdit(QKeySequenceEdit):
             self.setKeySequence('')
 
     def get_str(self) -> str:
-        """Get the hotkey value as a string
+        """Get the hotkey value as a string.
 
         Returns
         -------
-        requested string
+        Requested string.
         """
         out_str = self.keySequence().toString()
 
@@ -350,12 +350,12 @@ class OverlaySequenceEdit(QKeySequenceEdit):
 
 
 def popup_message(title: str, msg_text: str):
-    """Open a popup message
+    """Open a popup message.
 
     Parameters
     ----------
-    title       title of the popup window
-    msg_text    message to display
+    title       Title of the popup window.
+    msg_text    Message to display.
     """
     msg = QMessageBox()
     msg.setWindowTitle(title)

--- a/prepare_release.py
+++ b/prepare_release.py
@@ -10,11 +10,11 @@ def compile_clean(name_overlay: str, game_folder: str, out_lib_name: str,
 
     Parameters
     ----------
-    name_overlay       name of this overlay executable
-    game_folder        specific game folder name for the path
-    out_lib_name       name of the output library
-    disable_console    True to disable the console output
-    finalize_folder    True to finalize the folder (copy additional files, zip, clean)
+    name_overlay       Name of this overlay executable.
+    game_folder        Specific game folder name for the path.
+    out_lib_name       Name of the output library.
+    disable_console    True to disable the console output.
+    finalize_folder    True to finalize the folder (copy additional files, zip, clean).
     """
     icon = 'pictures/common/icon/salamander_sword_shield.ico'  # icon for the library
 

--- a/sc2/sc2_build_order.py
+++ b/sc2/sc2_build_order.py
@@ -1,7 +1,7 @@
 from sc2.sc2_race_icon import sc2_race_icon
 from common.build_order_tools import convert_txt_note_to_illustrated
 
-# dictionary from Spawning Tool BO to SC2 stored images
+# Dictionary from Spawning Tool BO to SC2 stored images
 sc2_pictures_dict = {
     'Baneling': 'zerg_units/Baneling.png',
     'Brood Lord': 'zerg_units/Brood_Lord.png',
@@ -225,17 +225,17 @@ sc2_pictures_dict = {
 
 
 def check_valid_sc2_build_order(data: dict, bo_name_msg: bool = False) -> (bool, str):
-    """Check if a build order is valid for SC2
+    """Check if a build order is valid for SC2.
 
     Parameters
     ----------
-    data           data of the build order JSON file
-    bo_name_msg    True to add the build order name in the error message
+    data           Data of the build order JSON file.
+    bo_name_msg    True to add the build order name in the error message.
 
     Returns
     -------
-    True if valid build order, False otherwise
-    string indicating the error (empty if no error)
+    True if valid build order, False otherwise.
+    String indicating the error (empty if no error).
     """
     bo_name_str: str = ''
     try:
@@ -314,13 +314,13 @@ def get_sc2_build_order_from_spawning_tool(
 
     Parameters
     ----------
-    data             data copied from https://lotv.spawningtool.com
-    race             player race
-    opponent_race    opponent race (can also be 'Any')
-    name             name of the build order
-    patch            patch of the build order
-    author           author of the build order
-    source           source of the build order
+    data             Data copied from https://lotv.spawningtool.com.
+    race             Player race.
+    opponent_race    Opponent race (can also be 'Any').
+    name             Name of the build order.
+    patch            Patch of the build order.
+    author           Author of the build order.
+    source           Source of the build order.
 
     Returns
     -------
@@ -378,7 +378,7 @@ def get_sc2_build_order_step(build_order_data: dict = None) -> dict:
 
     Parameters
     ----------
-    build_order_data    data with the build order
+    build_order_data    Data with the build order.
 
     Returns
     -------

--- a/sc2/sc2_build_order.py
+++ b/sc2/sc2_build_order.py
@@ -373,23 +373,41 @@ def get_sc2_build_order_from_spawning_tool(
     return out_data
 
 
-def get_sc2_build_order_step() -> dict:
+def get_sc2_build_order_step(build_order_data: dict = None) -> dict:
     """Get one step of the SC2 build order (template).
+
+    Parameters
+    ----------
+    build_order_data    data with the build order
 
     Returns
     -------
     Dictionary with the build order step template.
     """
-    return {
-        'time': '0:00',
-        'supply': -1,
-        'minerals': -1,
-        'vespene_gas': -1,
-        'notes': [
-            'Note 1.',
-            'Note 2.'
-        ]
-    }
+    if build_order_data is not None:
+        assert isinstance(build_order_data, list) and len(build_order_data) >= 1
+        data = build_order_data[-1]  # last step data
+        return {
+            'time': data['time'] if ('time' in data) else '0:00',
+            'supply': data['supply'] if ('supply' in data) else -1,
+            'minerals': data['minerals'] if ('minerals' in data) else -1,
+            'vespene_gas': data['vespene_gas'] if ('vespene_gas' in data) else -1,
+            'notes': [
+                'Note 1.',
+                'Note 2.'
+            ]
+        }
+    else:
+        return {
+            'time': '0:00',
+            'supply': -1,
+            'minerals': -1,
+            'vespene_gas': -1,
+            'notes': [
+                'Note 1.',
+                'Note 2.'
+            ]
+        }
 
 
 def get_sc2_build_order_template() -> dict:

--- a/sc2/sc2_game_overlay.py
+++ b/sc2/sc2_game_overlay.py
@@ -9,7 +9,6 @@ from PyQt5.QtCore import QSize
 from common.useful_tools import widget_x_end, widget_y_end, scale_list_int
 from common.rts_overlay import RTSGameOverlay, PanelID
 from common.build_order_window import BuildOrderWindow
-from common.build_order_tools import get_build_order_timer_steps_display
 from common.rts_settings import RTSBuildOrderInputLayout
 
 from sc2.sc2_settings import SC2OverlaySettings
@@ -22,18 +21,18 @@ def initialize_race_combo(race_select: QComboBox, opponent_race_select: QComboBo
                           race_combo_ids: list, opponent_race_combo_ids: list,
                           directory_game_pictures: str, icon_select_size: list,
                           color_background: list, color_default: list):
-    """Initialize the combo boxes for race selection
+    """Initialize the combo boxes for race selection.
 
     Parameters
     ----------
-    race_select                combo box for the player race to select
-    opponent_race_select       combo box for the opponent race to select
-    race_combo_ids             list of races corresponding to the combo box 'race_select'
-    opponent_race_combo_ids    list of races corresponding to the combo box 'opponent_race_select'
-    directory_game_pictures    directory where the game pictures are located
-    icon_select_size           size of the icon for race selection
-    color_background           color of the background
-    color_default              default color for the text
+    race_select                Combo box for the player race to select.
+    opponent_race_select       Combo box for the opponent race to select.
+    race_combo_ids             List of races corresponding to the combo box 'race_select'.
+    opponent_race_combo_ids    List of races corresponding to the combo box 'opponent_race_select'.
+    directory_game_pictures    Directory where the game pictures are located.
+    icon_select_size           Size of the icon for race selection.
+    color_background           Color of the background.
+    color_default              Default color for the text.
     """
     for race_item in range(2):  # player race, then opponent race
         selected_race_select = race_select if (race_item == 0) else opponent_race_select
@@ -58,7 +57,7 @@ def initialize_race_combo(race_select: QComboBox, opponent_race_select: QComboBo
 
 
 class SC2BuildOrderWindow(BuildOrderWindow):
-    """Window to add a new build order, for SC2"""
+    """Window to add a new build order, for SC2."""
 
     def __init__(self, app: QApplication, parent: RTSGameOverlay, game_icon: str, build_order_folder: str,
                  panel_settings: RTSBuildOrderInputLayout, edit_init_text: str, build_order_websites: list,
@@ -67,16 +66,16 @@ class SC2BuildOrderWindow(BuildOrderWindow):
 
         Parameters
         ----------
-        app                          main application instance
-        parent                       the parent window
-        game_icon                    icon of the game
-        build_order_folder           folder where the build orders are saved
-        panel_settings               settings for the panel layout
-        edit_init_text               initial text for the build order text input
-        build_order_websites         list of website elements as [[button name 0, website link 0], [...]],
-                                     (each item contains these 2 elements)
-        directory_game_pictures      directory where the game pictures are located
-        directory_common_pictures    directory where the common pictures are located
+        app                          Main application instance.
+        parent                       The parent window.
+        game_icon                    Icon of the game.
+        build_order_folder           Folder where the build orders are saved.
+        panel_settings               Settings for the panel layout.
+        edit_init_text               Initial text for the build order text input.
+        build_order_websites         List of website elements as [[button name 0, website link 0], [...]],
+                                     (each item contains these 2 elements).
+        directory_game_pictures      Directory where the game pictures are located.
+        directory_common_pictures    Directory where the common pictures are located.
         """
         super().__init__(app=app, parent=parent, game_icon=game_icon, build_order_folder=build_order_folder,
                          panel_settings=panel_settings, edit_init_text=edit_init_text,
@@ -108,15 +107,15 @@ class SC2BuildOrderWindow(BuildOrderWindow):
 
 
 class SC2GameOverlay(RTSGameOverlay):
-    """Game overlay application for SC2"""
+    """Game overlay application for SC2."""
 
     def __init__(self, app: QApplication, directory_main: str):
         """Constructor
 
         Parameters
         ----------
-        app               main application instance
-        directory_main    directory where the main file is located
+        app               Main application instance.
+        directory_main    Directory where the main file is located.
         """
         super().__init__(app=app, directory_main=directory_main, name_game='sc2', settings_name='sc2_settings.json',
                          settings_class=SC2OverlaySettings, check_valid_build_order=check_valid_sc2_build_order,
@@ -172,17 +171,12 @@ class SC2GameOverlay(RTSGameOverlay):
         self.race_combo_ids = []  # corresponding IDs
         self.opponent_race_combo_ids = []
 
-        self.show_resources = False  # True to show the resources in the build order current display
-
         initialize_race_combo(self.race_select, self.opponent_race_select, self.race_combo_ids,
                               self.opponent_race_combo_ids, self.directory_game_pictures,
                               icon_select_size, color_background, color_default)
 
         self.race_select.activated.connect(self.update_build_order_display)
         self.opponent_race_select.activated.connect(self.update_build_order_display)
-
-        # create build orders folder
-        os.makedirs(self.directory_build_orders, exist_ok=True)
 
         self.update_panel_elements()  # update the current panel elements
 
@@ -191,7 +185,7 @@ class SC2GameOverlay(RTSGameOverlay):
 
         Parameters
         ----------
-        update_settings   True to update (reload) the settings, False to keep the current ones
+        update_settings   True to update (reload) the settings, False to keep the current ones.
         """
         super().reload(update_settings=update_settings)
 
@@ -217,25 +211,51 @@ class SC2GameOverlay(RTSGameOverlay):
         self.update_panel_elements()  # update the current panel elements
 
     def settings_scaling(self):
-        """Apply the scaling on the settings"""
+        """Apply the scaling on the settings."""
         super().settings_scaling()
         assert 0 <= self.scaling_input_selected_id < len(self.scaling_input_combo_ids)
-        layout = self.settings.layout
-        unscaled_layout = self.unscaled_settings.layout
         scaling = self.scaling_input_combo_ids[self.scaling_input_selected_id] / 100.0
 
-        layout.configuration.icon_select_size = scale_list_int(
-            scaling, unscaled_layout.configuration.icon_select_size)
+        self.settings.layout.configuration.icon_select_size = scale_list_int(
+            scaling, self.unscaled_settings.layout.configuration.icon_select_size)
+
+    def select_build_order_id(self, build_order_id: int = -1) -> bool:
+        """Select build order ID.
+
+        Parameters
+        ----------
+        build_order_id    ID of the build order, negative to select next build order.
+
+        Returns
+        -------
+        True if valid build order selection.
+        """
+        if self.selected_panel == PanelID.CONFIG:
+            if super().select_build_order_id(build_order_id):
+                race_id = self.race_select.currentIndex()
+                opponent_race_id = self.opponent_race_select.currentIndex()
+                assert 0 <= race_id < len(self.race_combo_ids)
+                assert 0 <= opponent_race_id < len(self.opponent_race_combo_ids)
+                self.obtain_build_order_search(
+                    key_condition={'race': self.race_combo_ids[race_id],
+                                   'opponent_race': self.opponent_race_combo_ids[opponent_race_id]})
+                if build_order_id >= 0:  # directly select in case of clicking
+                    self.select_build_order(key_condition={
+                        'race': self.race_combo_ids[self.race_select.currentIndex()],
+                        'opponent_race': self.opponent_race_combo_ids[self.opponent_race_select.currentIndex()]})
+                self.config_panel_layout()
+                return True
+        return False
 
     def hide_elements(self):
-        """Hide elements"""
+        """Hide elements."""
         super().hide_elements()
 
         self.race_select.hide()
         self.opponent_race_select.hide()
 
     def update_build_order_display(self):
-        """Update the build order search matching display"""
+        """Update the build order search matching display."""
         race_id = self.race_select.currentIndex()
         opponent_race_id = self.opponent_race_select.currentIndex()
         assert (0 <= race_id < len(self.race_combo_ids)) and (0 <= opponent_race_id < len(self.opponent_race_combo_ids))
@@ -244,9 +264,36 @@ class SC2GameOverlay(RTSGameOverlay):
                            'opponent_race': self.opponent_race_combo_ids[opponent_race_id]})
         self.config_panel_layout()
 
+    def enter_key_actions(self):
+        """Actions performed when pressing the Enter key."""
+        if self.selected_panel == PanelID.CONFIG:
+            if self.build_order_search.hasFocus():
+                self.select_build_order(key_condition={
+                    'race': self.race_combo_ids[self.race_select.currentIndex()],
+                    'opponent_race': self.opponent_race_combo_ids[self.opponent_race_select.currentIndex()]})
+
+            self.config_panel_layout()  # update layout
+
+    def open_panel_add_build_order(self):
+        """Open/close the panel to add a build order, specialized for SC2."""
+        super().open_panel_add_build_order()
+
+        if (self.panel_add_build_order is not None) and self.panel_add_build_order.isVisible():  # close panel
+            self.panel_add_build_order.close()
+            self.panel_add_build_order = None
+        else:  # open new panel
+            self.panel_add_build_order = SC2BuildOrderWindow(
+                app=self.app, parent=self, game_icon=self.game_icon, build_order_folder=self.directory_build_orders,
+                panel_settings=self.settings.panel_build_order, edit_init_text=self.build_order_instructions,
+                build_order_websites=[['Spawning Tool', 'https://lotv.spawningtool.com']],
+                directory_game_pictures=self.directory_game_pictures,
+                directory_common_pictures=self.directory_common_pictures)
+
     def config_panel_layout(self):
-        """Layout of the configuration panel"""
+        """Layout of the configuration panel."""
         super().config_panel_layout()
+        if self.selected_panel != PanelID.CONFIG:
+            return
 
         # show elements
         self.race_select.show()
@@ -291,87 +338,23 @@ class SC2GameOverlay(RTSGameOverlay):
 
         self.build_order_selection.update_size_position(init_y=next_y)
 
-        max_x = max(widget_x_end(self.next_panel_button), widget_x_end(self.build_order_search),
-                    self.build_order_selection.x() + self.build_order_selection.row_max_width)
-
-        max_y = max(widget_y_end(self.build_order_search),
-                    self.build_order_selection.y() + self.build_order_selection.row_total_height)
-
-        # resize main window
-        self.resize(max_x + border_size, max_y + border_size)
-
-        # next panel on top right corner
-        self.next_panel_button.move(self.width() - border_size - self.next_panel_button.width(), border_size)
-
-        # update position (in case the size changed)
-        self.update_position()
-
-    def select_build_order_id(self, build_order_id: int = -1) -> bool:
-        """Select build order ID
-
-        Parameters
-        ----------
-        build_order_id    ID of the build order, negative to select next build order
-
-        Returns
-        -------
-        True if valid build order selection
-        """
-        if self.selected_panel == PanelID.CONFIG:
-            if super().select_build_order_id(build_order_id):
-                race_id = self.race_select.currentIndex()
-                opponent_race_id = self.opponent_race_select.currentIndex()
-                assert 0 <= race_id < len(self.race_combo_ids)
-                assert 0 <= opponent_race_id < len(self.opponent_race_combo_ids)
-                self.obtain_build_order_search(
-                    key_condition={'race': self.race_combo_ids[race_id],
-                                   'opponent_race': self.opponent_race_combo_ids[opponent_race_id]})
-                if build_order_id >= 0:  # directly select in case of clicking
-                    self.select_build_order(key_condition={
-                        'race': self.race_combo_ids[self.race_select.currentIndex()],
-                        'opponent_race': self.opponent_race_combo_ids[self.opponent_race_select.currentIndex()]})
-                self.config_panel_layout()
-                return True
-        return False
+        self.config_panel_layout_resize_move()  # size and position
 
     def update_build_order(self):
-        """Update the build order panel"""
+        """Update the build order panel."""
         super().update_build_order()
-
-        layout = self.settings.layout
-        self.adapt_notes_to_columns = -1  # no column adaptation by default
 
         # valid build order selected
         if (self.selected_build_order is not None) and ('build_order' in self.selected_build_order):
 
-            if self.build_order_timer['use_timer'] and self.build_order_timer['steps']:
-                # get steps to display
-                selected_steps_ids, selected_steps = get_build_order_timer_steps_display(
-                    self.build_order_timer['steps'], self.build_order_timer['steps_ids'])
-            else:
-                selected_build_order_content = self.selected_build_order['build_order']
+            layout = self.settings.layout
+            spacing = ' ' * layout.build_order.resource_spacing  # space between the elements
 
-                # select current step
-                assert 0 <= self.selected_build_order_step_id < self.selected_build_order_step_count
-                selected_steps_ids = [0]
-                selected_steps = [selected_build_order_content[self.selected_build_order_step_id]]
-                assert selected_steps[0] is not None
-            assert (len(selected_steps) > 0) and (len(selected_steps_ids) > 0)
-
-            # space between the elements
-            spacing = ''
-            for i in range(layout.build_order.resource_spacing):
-                spacing += ' '
-
-            # display selected step
-            if self.build_order_timer['use_timer']:
-                self.update_build_order_time_label()
-            else:
-                self.update_build_order_step_label()
-
-            images = self.settings.images
+            # get selected steps and corresponding IDs
+            selected_steps, selected_steps_ids = self.get_build_order_selected_steps_and_ids()
 
             # resource line
+            images = self.settings.images
             resource_step = selected_steps[selected_steps_ids[-1]]  # ID of the step to use to display the resources
             resources_line = ''
 
@@ -389,106 +372,7 @@ class SC2GameOverlay(RTSGameOverlay):
                 resources_line = resources_line[layout.build_order.resource_spacing:]  # remove initial spacing
                 self.build_order_resources.add_row_from_picture_line(parent=self, line=str(resources_line))
 
-            # line before notes
-            self.build_order_notes.add_row_color(
-                parent=self, height=layout.build_order.height_line_notes, color=layout.build_order.color_line_notes)
-
-            # loop on the steps for notes
-            for step_id, selected_step in enumerate(selected_steps):
-
-                # check if emphasis must be added on the corresponding note
-                emphasis_flag = self.build_order_timer['run_timer'] and (step_id in selected_steps_ids)
-
-                notes = selected_step['notes']
-                for note_id, note in enumerate(notes):
-                    # add time if running timer and time available
-                    line = ''
-                    if (self.build_order_timer['use_timer']) and ('time' in resource_step) and hasattr(
-                            layout.build_order, 'show_time_in_notes') and layout.build_order.show_time_in_notes:
-                        line += (str(selected_step['time']) if (note_id == 0) else ' ') + '@' + spacing + '@'
-                        self.adapt_notes_to_columns = 1
-                    line += note
-                    self.build_order_notes.add_row_from_picture_line(
-                        parent=self, line=line, emphasis_flag=emphasis_flag)
+            # update the notes of the build order
+            self.update_build_order_notes(selected_steps, selected_steps_ids)
 
         self.build_order_panel_layout()  # update layout
-
-    def build_order_panel_layout(self):
-        """Layout of the Build order panel"""
-        super().build_order_panel_layout()
-
-        # show elements
-        if self.show_resources:
-            self.build_order_resources.show()
-
-        # size and position
-        layout = self.settings.layout
-        border_size = layout.border_size
-        vertical_spacing = layout.vertical_spacing
-        horizontal_spacing = layout.horizontal_spacing
-        action_button_size = layout.action_button_size
-        action_button_spacing = layout.action_button_spacing
-        bo_next_tab_spacing = layout.build_order.bo_next_tab_spacing
-
-        # action buttons
-        next_y = border_size + action_button_size + vertical_spacing
-
-        if self.selected_build_order is not None:
-            self.build_order_step_time.adjustSize()
-            next_y = max(next_y, border_size + self.build_order_step_time.height() + vertical_spacing)
-
-        # build order resources
-        if self.show_resources:
-            self.build_order_resources.update_size_position(init_y=next_y)
-            next_y += self.build_order_resources.row_total_height + vertical_spacing
-
-        # maximum width
-        buttons_count = 3  # previous step + next step + next panel
-        if self.build_order_timer['available']:
-            buttons_count += 3 if self.build_order_timer[
-                'use_timer'] else 1  # switch timer-manual (+ start/stop + reset timer)
-        max_x = max(
-            (self.build_order_step_time.width() + buttons_count * action_button_size +
-             horizontal_spacing + (buttons_count - 2) * action_button_spacing + bo_next_tab_spacing),
-            self.build_order_resources.row_max_width)
-
-        # build order notes
-        self.build_order_notes.update_size_position(
-            init_y=next_y, panel_init_width=max_x + 2 * border_size,
-            adapt_to_columns=self.adapt_notes_to_columns)
-
-        # resize of the full window
-        max_x = max(max_x, self.build_order_notes.row_max_width)
-        self.resize(max_x + 2 * border_size, next_y + self.build_order_notes.row_total_height + border_size)
-
-        # adapt buttons positions after window resize
-        self.build_order_panel_layout_action_buttons()
-
-        # position update to stay with the same upper right corner position
-        self.update_position()
-
-    def enter_key_actions(self):
-        """Actions performed when pressing the Enter key"""
-        if self.selected_panel == PanelID.CONFIG:
-            if self.build_order_search.hasFocus():
-                self.select_build_order(key_condition={
-                    'race': self.race_combo_ids[self.race_select.currentIndex()],
-                    'opponent_race': self.opponent_race_combo_ids[self.opponent_race_select.currentIndex()]})
-
-            self.config_panel_layout()  # update layout
-
-    def open_panel_add_build_order(self):
-        """Open/close the panel to add a build order, specialized for SC2"""
-        super().open_panel_add_build_order()
-
-        if (self.panel_add_build_order is not None) and self.panel_add_build_order.isVisible():  # close panel
-            self.panel_add_build_order.close()
-            self.panel_add_build_order = None
-        else:  # open new panel
-            config = self.settings.panel_build_order
-            self.panel_add_build_order = SC2BuildOrderWindow(
-                app=self.app, parent=self, game_icon=self.game_icon, build_order_folder=self.directory_build_orders,
-                panel_settings=self.settings.panel_build_order, edit_init_text=self.build_order_instructions,
-                build_order_websites=[['Spawning Tool', 'https://lotv.spawningtool.com']],
-                directory_game_pictures=self.directory_game_pictures,
-                directory_common_pictures=self.directory_common_pictures)

--- a/sc2/sc2_game_overlay.py
+++ b/sc2/sc2_game_overlay.py
@@ -485,6 +485,8 @@ class SC2GameOverlay(RTSGameOverlay):
 
     def open_panel_add_build_order(self):
         """Open/close the panel to add a build order, specialized for SC2"""
+        super().open_panel_add_build_order()
+
         if (self.panel_add_build_order is not None) and self.panel_add_build_order.isVisible():  # close panel
             self.panel_add_build_order.close()
             self.panel_add_build_order = None

--- a/sc2/sc2_game_overlay.py
+++ b/sc2/sc2_game_overlay.py
@@ -337,19 +337,14 @@ class SC2GameOverlay(RTSGameOverlay):
 
     def update_build_order(self):
         """Update the build order panel"""
-
-        # clear the elements (also hide them)
-        self.build_order_resources.clear()
-        self.build_order_notes.clear()
+        super().update_build_order()
 
         layout = self.settings.layout
-
         self.adapt_notes_to_columns = -1  # no column adaptation by default
 
-        if self.selected_build_order is None:  # no build order selected
-            self.build_order_notes.add_row_from_picture_line(parent=self, line='No build order selected.')
+        # valid build order selected
+        if (self.selected_build_order is not None) and ('build_order' in self.selected_build_order):
 
-        else:  # valid build order selected
             if self.build_order_timer['use_timer'] and self.build_order_timer['steps']:
                 # get steps to display
                 selected_steps_ids, selected_steps = get_build_order_timer_steps_display(

--- a/sc2/sc2_game_overlay.py
+++ b/sc2/sc2_game_overlay.py
@@ -381,7 +381,7 @@ class SC2GameOverlay(RTSGameOverlay):
                 resources_line += spacing + '@' + images.vespene_gas + '@ ' + str(resource_step['vespene_gas'])
             if ('supply' in resource_step) and (resource_step['supply'] >= 0):
                 resources_line += spacing + '@' + images.supply + '@ ' + str(resource_step['supply'])
-            if ('time' in resource_step) and (resource_step['time'] != ''):
+            if layout.show_time_resource and ('time' in resource_step) and (resource_step['time'] != ''):
                 resources_line += spacing + '@' + images.time + '@ ' + str(resource_step['time'])
 
             self.show_resources = (resources_line != '')

--- a/sc2/sc2_game_overlay.py
+++ b/sc2/sc2_game_overlay.py
@@ -123,8 +123,7 @@ class SC2GameOverlay(RTSGameOverlay):
                          get_build_order_step=get_sc2_build_order_step,
                          get_build_order_template=get_sc2_build_order_template,
                          get_faction_selection=get_sc2_faction_selection,
-                         build_order_category_name='race',
-                         build_order_timer_available=True)
+                         build_order_category_name='race')
 
         # build order instructions
         self.build_order_instructions = \

--- a/sc2/sc2_settings.py
+++ b/sc2/sc2_settings.py
@@ -1,6 +1,6 @@
 import json
-from common.rts_settings import RTSConfigurationLayout, RTSLayout, RTSTimerImages, RTSOverlaySettings, \
-    RTSBuildOrderTimerLayout, RTSTimerHotkeys
+from common.rts_settings import RTSConfigurationLayout, RTSLayout, RTSOverlaySettings, \
+    RTSTimerImages, RTSBuildOrderTimerLayout, RTSTimerHotkeys
 
 
 class SC2ConfigurationLayout(RTSConfigurationLayout):
@@ -50,8 +50,6 @@ class SC2OverlaySettings(RTSOverlaySettings):
     def __init__(self):
         """Constructor"""
         super().__init__()
-
-        self.timer_available: bool = True  # timer feature available
 
         self.title: str = 'SC2 Overlay'  # application title
 

--- a/utilities/convert_images.py
+++ b/utilities/convert_images.py
@@ -7,16 +7,16 @@ from PIL import Image  # pip install pillow
 def convert_images(in_folder_path: str, out_folder_path: str,
                    in_ext: list = ('webp', 'gif', 'png', 'jpg', 'jfif'), out_ext: str = ('png', 'jpg'),
                    max_size: int = -1):
-    """Convert images from one format to another
+    """Convert images from one format to another.
 
     Parameters
     ----------
-    in_folder_path     input folder path
-    out_folder_path    output folder path
-    in_ext             input extensions to look for
-    out_ext            generated output extension, will keep the same extension as input if it is in the list,
-                       otherwise will use the first extension of the list
-    max_size           maximum size along both width and height, negative to ignore
+    in_folder_path     Input folder path.
+    out_folder_path    Output folder path.
+    in_ext             Input extensions to look for.
+    out_ext            Generated output extension, will keep the same extension as input if it is in the list,
+                       otherwise will use the first extension of the list.
+    max_size           Maximum size along both width and height, negative to ignore.
     """
     assert len(out_ext) >= 1
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.9.0",
+    "version": "1.9.1",
     "name": "RTS Overlay",
     "project": "https://github.com/CraftySalamander/RTS_Overlay"
 }


### PR DESCRIPTION
* Option to keep the BO writer and hotkeys configuration always on top.
* Add hotkeys to only start OR stop the BO timing run.
* BO writer panel
    * Switch to build order panel when opening the BO writer panel.
    * Button to display the BO being built.
    * Add BO step using resources from previous step if available.
    * Focus on the end of the BO when formatting or adding a step.
    * Check if BO is valid for timing and display it.
* AoE2
    * Do not copy sample BOs at creation (outdated BOs).
* AoE2 & AoE4
    * Build order timing evaluation function.
    * Build order timing feature available (like SC2).
    * Remove tooltip feature (generating issues with BO panel).