### PR TITLE
Replace "mouse" with "pynput" implementation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyQt5==5.15.7
 keyboard==0.13.5
-mouse==0.7.1
 appdirs==1.4.4
 thefuzz==0.19.0
+pynput==1.7.7


### PR DESCRIPTION
Took a stab at #19 as it seemed available and I've been wanting to use RTS Overlay for aoe2 for a while now.

PR is meant to solve the issue of needing root privilege (or running as root causing other problems) by replacing "mouse" with "pynput" which doesn't require elevated privileges.
- the individual button callbacks were from mouse were replaced with a continuous mouse listener, as that made more sense to me with pynput
- on_click handles mouse button events
- __del__ method to cleanup the mouse listener

Tested on Linux.

Lemme know if it's alright, cheers.