### PR TITLE
Fetch the build order from an external API

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,9 @@
 ## in progress
 * Web overlay
     * Display the full BO in a single panel on a new page.
+    * Adding ?aoe2, ?aoe4, ?aom or ?sc2 at the end of the url will open the overlay with the corresponding game instead of the default AoE2.
+    * AoE4
+        * The aoe4guides.com BOs can be directly fetched through the RTS Overlay URL.
 
 ## [2.1.0] - 2024.09.24
 * First release of Age of Mythology (AoM).

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 ## in progress
 * Web overlay
     * Display the full BO in a single panel on a new page.
-    * Adding ?aoe2, ?aoe4, ?aom or ?sc2 at the end of the url will open the overlay with the corresponding game instead of the default AoE2.
+    * Adding `gameID=xxx` at the end of the url will open the overlay with the corresponding game instead of the default AoE2.
     * AoE4
         * The aoe4guides.com BOs can be directly fetched through the RTS Overlay URL.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-## in progress
+## [2.2.0] - 2024.11.15
 * Web overlay
     * Display the full BO in a single panel on a new page.
     * Adding `gameID=xxx` at the end of the url will open the overlay with the corresponding game instead of the default AoE2.

--- a/docs/rts_overlay.js
+++ b/docs/rts_overlay.js
@@ -3215,46 +3215,41 @@ function openSinglePanelPageFromDescription(
   }
   htmlContent += indentSpace(2) + '</tr>\n';
 
-  let lastSectionHeaderKey = null;  // last key for section header
-  let previousHeaderFlag = false;   // header was activated in previous step
+  let lastSectionHeaderKey = null;  // last key value for section header
 
   // Loop on all the build order steps
   for (const currentStep of buildOrderData) {
     const notes = currentStep['notes'];
 
-    // Section header
+    let currentSectionHeaderKey = null;  // current key value for section header
+
     if (sectionsHeader) {
       // Key to check for section header
       console.assert(
           sectionsHeader.key in currentStep,
           'Current step is missing \'' + sectionsHeader.key + '\'.');
-      const keyValue = currentStep[sectionsHeader.key];
+      currentSectionHeaderKey = currentStep[sectionsHeader.key];
 
-      // Activate if first line or seen in the previous line
-      if ((!lastSectionHeaderKey || previousHeaderFlag)) {
-        if (sectionsHeader.after && (keyValue in sectionsHeader.after)) {
-          htmlContent += indentSpace(2) + '<tr class="border_top">\n';
-          htmlContent += indentSpace(3) + '<td class="full_line" colspan=8>' +
-              sectionsHeader.after[keyValue] + '</td>\n';
-          htmlContent += indentSpace(2) + '</tr>\n';
-        }
-        previousHeaderFlag = false;
-      }
-      // Activate if new key
-      else if ((keyValue !== lastSectionHeaderKey)) {
-        if (sectionsHeader.before && (keyValue in sectionsHeader.before)) {
-          htmlContent += indentSpace(2) + '<tr class="border_top">\n';
-          htmlContent += indentSpace(3) + '<td class="full_line" colspan=8>' +
-              sectionsHeader.before[keyValue] + '</td>\n';
-          htmlContent += indentSpace(2) + '</tr>\n';
-        }
-        previousHeaderFlag = true;
-      } else {
-        previousHeaderFlag = false;
+      // Header section before first line
+      if (sectionsHeader.first_line &&
+          (currentSectionHeaderKey in sectionsHeader.first_line) &&
+          !lastSectionHeaderKey) {
+        htmlContent += indentSpace(2) + '<tr class="border_top">\n';
+        htmlContent += indentSpace(3) + '<td class="full_line" colspan=8>' +
+            sectionsHeader.first_line[currentSectionHeaderKey] + '</td>\n';
+        htmlContent += indentSpace(2) + '</tr>\n';
       }
 
-      // Save last key value seen
-      lastSectionHeaderKey = keyValue;
+      // Header section before current line
+      if (sectionsHeader.before &&
+          (currentSectionHeaderKey in sectionsHeader.before) &&
+          lastSectionHeaderKey &&
+          (currentSectionHeaderKey !== lastSectionHeaderKey)) {
+        htmlContent += indentSpace(2) + '<tr class="border_top">\n';
+        htmlContent += indentSpace(3) + '<td class="full_line" colspan=8>' +
+            sectionsHeader.before[currentSectionHeaderKey] + '</td>\n';
+        htmlContent += indentSpace(2) + '</tr>\n';
+      }
     }
 
     // Loop on the notes
@@ -3310,6 +3305,22 @@ function openSinglePanelPageFromDescription(
           '<div>' + noteToTextImages(note) + '</div>\n' + indentSpace(3) +
           '</td>\n';
       htmlContent += indentSpace(2) + '</tr>\n';
+    }
+
+    if (sectionsHeader) {
+      // Header section after current line
+      if (sectionsHeader.after &&
+          (currentSectionHeaderKey in sectionsHeader.after) &&
+          lastSectionHeaderKey &&
+          (currentSectionHeaderKey !== lastSectionHeaderKey)) {
+        htmlContent += indentSpace(2) + '<tr class="border_top">\n';
+        htmlContent += indentSpace(3) + '<td class="full_line" colspan=8>' +
+            sectionsHeader.after[currentSectionHeaderKey] + '</td>\n';
+        htmlContent += indentSpace(2) + '</tr>\n';
+      }
+
+      // Save last key value seen
+      lastSectionHeaderKey = currentSectionHeaderKey;
     }
   }
 
@@ -4475,6 +4486,8 @@ function openSinglePanelPageAoE2() {
           'Imperial Age'
     }
   };
+  // Header for first line
+  sectionsHeader['first_line'] = sectionsHeader.after;
 
   // Feed game description to generic function
   openSinglePanelPageFromDescription(columnsDescription, sectionsHeader);
@@ -5073,6 +5086,8 @@ function openSinglePanelPageAoE4() {
       4: getBOImageHTML(game + 'age/age_4.png') + 'Imperial Age'
     }
   };
+  // Header for first line
+  sectionsHeader['first_line'] = sectionsHeader.after;
 
   // Feed game description to generic function
   openSinglePanelPageFromDescription(columnsDescription, sectionsHeader);
@@ -5610,6 +5625,8 @@ function openSinglePanelPageAoM() {
       5: getBOImageHTML(game + 'age/wonder_age.png') + 'Wonder Age'
     }
   };
+  // Header for first line
+  sectionsHeader['first_line'] = sectionsHeader.after;
 
   // Feed game description to generic function
   openSinglePanelPageFromDescription(columnsDescription, sectionsHeader);

--- a/docs/rts_overlay.js
+++ b/docs/rts_overlay.js
@@ -3103,6 +3103,7 @@ function openSinglePanelPageFromDescription(
   htmlContent += indentSpace(3) + 'margin: 0 auto;\n';
   htmlContent += indentSpace(3) + 'border-radius: 15px;\n';
   htmlContent += indentSpace(3) + 'border-collapse: collapse;\n';
+  htmlContent += indentSpace(3) + 'margin-bottom: 30px;\n';
   htmlContent += indentSpace(2) + '}\n\n';
 
   htmlContent += indentSpace(2) + 'td {\n';
@@ -3151,6 +3152,8 @@ function openSinglePanelPageFromDescription(
   htmlContent += indentSpace(3) + 'padding-bottom: 3px;\n';
   htmlContent += indentSpace(3) + 'padding-left: 6px;\n';
   htmlContent += indentSpace(3) + 'padding-right: 6px;\n';
+  htmlContent += indentSpace(3) + 'margin-left: 3px;\n';
+  htmlContent += indentSpace(3) + 'margin-right: 3px;\n';
   htmlContent += indentSpace(2) + '}\n\n';
 
   htmlContent += indentSpace(2) + 'button:hover {\n';

--- a/docs/rts_overlay.js
+++ b/docs/rts_overlay.js
@@ -5125,13 +5125,10 @@ function openSinglePanelPageAoE4() {
   }
 
   // Sections Header
-  const topArrow = getBOImageHTML(common + 'icon/top_arrow.png');
   const sectionsHeader = {
     'key': 'age',  // Key to look for
     // Header before the current row
-    'before': null,
-    // Header after the current row
-    'after': {
+    'before': {
       1: getBOImageHTML(game + 'age/age_1.png') + 'Dark Age',
       2: getBOImageHTML(game + 'age/age_2.png') + 'Feudal Age',
       3: getBOImageHTML(game + 'age/age_3.png') + 'Castle Age',
@@ -5139,7 +5136,7 @@ function openSinglePanelPageAoE4() {
     }
   };
   // Header for first line
-  sectionsHeader['first_line'] = sectionsHeader.after;
+  sectionsHeader['first_line'] = sectionsHeader.before;
 
   // Feed game description to generic function
   openSinglePanelPageFromDescription(columnsDescription, sectionsHeader);

--- a/docs/rts_overlay.js
+++ b/docs/rts_overlay.js
@@ -1275,6 +1275,8 @@ function initConfigWindow() {
           if (result) {
             document.getElementById('bo_design').value = result;
             updateDataBO();
+            stepID = 0;
+            limitStepID();
             updateBOPanel(false);
           } else {
             console.log('Could not fetch the build order from aoe4guides.com.');

--- a/docs/rts_overlay.js
+++ b/docs/rts_overlay.js
@@ -56,10 +56,10 @@ const EXTERNAL_BO_WEBSITES = {
 
 // Fields of the faction name: player and (optionally) opponent
 const FACTION_FIELD_NAMES = {
-  'aoe2': { 'player': 'civilization', 'opponent': null },
-  'aoe4': { 'player': 'civilization', 'opponent': null },
-  'aom': { 'player': 'major_god', 'opponent': null },
-  'sc2': { 'player': 'race', 'opponent': 'opponent_race' }
+  'aoe2': {'player': 'civilization', 'opponent': null},
+  'aoe4': {'player': 'civilization', 'opponent': null},
+  'aom': {'player': 'major_god', 'opponent': null},
+  'sc2': {'player': 'race', 'opponent': 'opponent_race'}
 };
 
 // List of games where each step starts at the given time
@@ -73,7 +73,7 @@ const TIMER_SPEED_FACTOR = {
 // Special cases for the max number of images per row
 // (MAX_ROW_SELECT_IMAGES otherwise).
 const SPECIAL_MAX_ROW_SELECT_IMAGES = {
-  'aoe4': { 'select faction': 8, 'civilization_flag': 12 }
+  'aoe4': {'select faction': 8, 'civilization_flag': 12}
 };
 
 // Image to display when the requested image can not be loaded
@@ -104,7 +104,7 @@ let bo_panel_font_size = DEFAULT_BO_PANEL_FONTSIZE;
 let imageHeightBO = DEFAULT_BO_PANEL_IMAGES_SIZE;
 // Height of the action buttons.
 let actionButtonHeight =
-  ACTION_BUTTON_HEIGHT_RATIO * DEFAULT_BO_PANEL_IMAGES_SIZE;
+    ACTION_BUTTON_HEIGHT_RATIO * DEFAULT_BO_PANEL_IMAGES_SIZE;
 // Overlay on right or left side of the screen.
 let overlayOnRightSide = DEFAULT_OVERLAY_ON_RIGHT_SIDE;
 
@@ -113,10 +113,10 @@ let buildOrderTimer = {
   'step_starting_flag': false,  // true if the timer steps starts at the
   // indicated time, false if ending at this time
   'use_timer':
-    false,  // true to update BO with timer, false for manual selection
+      false,  // true to update BO with timer, false for manual selection
   'run_timer': false,  // true if the BO timer is running (false to stop)
   'absolute_time_init':
-    0.0,             // last absolute time when the BO timer run started [sec]
+      0.0,             // last absolute time when the BO timer run started [sec]
   'time_sec': 0.0,     // time for the BO [sec]
   'time_int': 0,       // 'time_sec' with a cast to integer
   'last_time_int': 0,  // last value for 'time_int' [sec]
@@ -196,9 +196,9 @@ function overlayResizeMove() {
 
   // Check if width/height require a change
   const widthFlag = (newWidth > currentWidth) ||
-    (newWidth < currentWidth - SIZE_UPDATE_THRESHOLD);
+      (newWidth < currentWidth - SIZE_UPDATE_THRESHOLD);
   const heightFlag = (newHeight > currentHeight) ||
-    (newHeight < currentHeight - SIZE_UPDATE_THRESHOLD);
+      (newHeight < currentHeight - SIZE_UPDATE_THRESHOLD);
 
   // Apply modifications if at least one dimension requires an update
   if (widthFlag || heightFlag) {
@@ -331,7 +331,7 @@ function getImagePath(imageSearch) {
     for (let image of images) {
       if (imageSearch === subFolder + '/' + image) {
         return 'assets/common' +
-          '/' + imageSearch;
+            '/' + imageSearch;
       }
     }
   }
@@ -355,8 +355,8 @@ function getImagePath(imageSearch) {
  * @returns Requested HTML code.
  */
 function getImageHTML(
-  imagePath, imageHeight, functionName = null, functionArgs = null,
-  tooltipText = null, imageID = null) {
+    imagePath, imageHeight, functionName = null, functionArgs = null,
+    tooltipText = null, imageID = null) {
   let imageHTML = '';
 
   // Add tooltip
@@ -368,19 +368,19 @@ function getImageHTML(
   if (functionName) {
     imageHTML += '<input type="image" src="' + imagePath + '"';
     imageHTML +=
-      ' onerror="this.onerror=null; this.src=\'' + ERROR_IMAGE + '\'"';
+        ' onerror="this.onerror=null; this.src=\'' + ERROR_IMAGE + '\'"';
     imageHTML += imageID ? ' id="' + imageID + '"' : '';
     imageHTML += ' height="' + imageHeight + '"';
     imageHTML += ' onclick="' + functionName +
-      (functionArgs ? '(\'' + functionArgs.replaceAll('\'', '\\\'') + '\')"' :
-        '()"');
+        (functionArgs ? '(\'' + functionArgs.replaceAll('\'', '\\\'') + '\')"' :
+                        '()"');
     imageHTML += '/>';
   }
   // Image (no button)
   else {
     imageHTML += '<img src="' + imagePath + '"';
     imageHTML +=
-      ' onerror="this.onerror=null; this.src=\'' + ERROR_IMAGE + '\'"';
+        ' onerror="this.onerror=null; this.src=\'' + ERROR_IMAGE + '\'"';
     imageHTML += imageID ? ' id="' + imageID + '"' : '';
     imageHTML += ' height="' + imageHeight + '">';
   }
@@ -521,9 +521,9 @@ function getBOPanelContent(overlayFlag, BOStepID) {
 
   // Configuration from within the BO panel
   const justifyFlex =
-    overlayOnRightSide ? 'justify_flex_end' : 'justify_flex_start';
+      overlayOnRightSide ? 'justify_flex_end' : 'justify_flex_start';
   htmlString +=
-    '<nobr><div class="bo_line bo_line_config ' + justifyFlex + '">';
+      '<nobr><div class="bo_line bo_line_config ' + justifyFlex + '">';
 
   // true to use the timer, false for manual selection
   const timingFlag = buildOrderTimer['use_timer'];
@@ -531,40 +531,40 @@ function getBOPanelContent(overlayFlag, BOStepID) {
   // Current step or time
   htmlString += '<div id="step_time_indication">';
   htmlString += timingFlag ? buildOrderTimer['last_time_label'] :
-    'Step: ' + (BOStepID + 1) + '/' + stepCount;
+                             'Step: ' + (BOStepID + 1) + '/' + stepCount;
   htmlString += '</div>';
 
   // Previous or next step
   const stepFunctionSuffix = overlayFlag ? 'Overlay' : 'Config';
 
   htmlString += getImageHTML(
-    commonPicturesFolder + 'action_button/previous.png', actionButtonHeight,
-    'previousStep' + stepFunctionSuffix, null,
-    timingFlag ? 'timer -1 sec' : 'previous BO step');
+      commonPicturesFolder + 'action_button/previous.png', actionButtonHeight,
+      'previousStep' + stepFunctionSuffix, null,
+      timingFlag ? 'timer -1 sec' : 'previous BO step');
   htmlString += getImageHTML(
-    commonPicturesFolder + 'action_button/next.png', actionButtonHeight,
-    'nextStep' + stepFunctionSuffix, null,
-    timingFlag ? 'timer +1 sec' : 'next BO step');
+      commonPicturesFolder + 'action_button/next.png', actionButtonHeight,
+      'nextStep' + stepFunctionSuffix, null,
+      timingFlag ? 'timer +1 sec' : 'next BO step');
 
   // Update timer
   if (timingFlag) {
     htmlString += getImageHTML(
-      commonPicturesFolder + 'action_button/' +
-      (buildOrderTimer['run_timer'] ? 'start_stop_active.png' :
-        'start_stop.png'),
-      actionButtonHeight, 'startStopBuildOrderTimer', null,
-      'start/stop the BO timer', 'start_stop_timer');
+        commonPicturesFolder + 'action_button/' +
+            (buildOrderTimer['run_timer'] ? 'start_stop_active.png' :
+                                            'start_stop.png'),
+        actionButtonHeight, 'startStopBuildOrderTimer', null,
+        'start/stop the BO timer', 'start_stop_timer');
     htmlString += getImageHTML(
-      commonPicturesFolder + 'action_button/timer_0.png', actionButtonHeight,
-      'resetBuildOrderTimer', null, 'reset the BO timer');
+        commonPicturesFolder + 'action_button/timer_0.png', actionButtonHeight,
+        'resetBuildOrderTimer', null, 'reset the BO timer');
   }
 
   // Switch between manual and timer
   if (overlayFlag && (buildOrderTimer['steps'].length > 0)) {
     htmlString += getImageHTML(
-      commonPicturesFolder + 'action_button/manual_timer_switch.png',
-      actionButtonHeight, 'switchBuildOrderTimerManual', null,
-      'switch BO mode between timer and manual');
+        commonPicturesFolder + 'action_button/manual_timer_switch.png',
+        actionButtonHeight, 'switchBuildOrderTimerManual', null,
+        'switch BO mode between timer and manual');
   }
   htmlString += '</div></nobr>';
 
@@ -584,7 +584,7 @@ function getBOPanelContent(overlayFlag, BOStepID) {
 
   if ('time' in resourceStep) {
     htmlString += getBOImageHTML(commonPicturesFolder + 'icon/time.png') +
-      resourceStep.time;
+        resourceStep.time;
   }
   htmlString += '</div></nobr>';
 
@@ -592,10 +592,10 @@ function getBOPanelContent(overlayFlag, BOStepID) {
   htmlString += '<hr style="width:100%;text-align:left;margin-left:0"></div>';
 
   // Loop on the steps for notes
-  selectedSteps.forEach(function (selectedStep, stepID) {
+  selectedSteps.forEach(function(selectedStep, stepID) {
     // Check if emphasis must be added on the corresponding note
     const emphasisFlag =
-      buildOrderTimer['run_timer'] && (selectedStepsIDs.includes(stepID));
+        buildOrderTimer['run_timer'] && (selectedStepsIDs.includes(stepID));
 
     // Notes of the current BO step
     const notes = selectedStep.notes;
@@ -620,7 +620,7 @@ function getBOPanelContent(overlayFlag, BOStepID) {
       // Add timing indication
       if (timingFlag && ('time' in selectedStep)) {
         htmlString += '<div class="bo_line_note_timing">' +
-          (noteID === 0 ? selectedStep.time : '') + '</div>';
+            (noteID === 0 ? selectedStep.time : '') + '</div>';
       }
 
       // Convert note line to HTML with text and images
@@ -666,7 +666,7 @@ function showHideItems() {
   const saveItems = ['save_bo_text', 'save_row'];
 
   const displayItems =
-    ['adapt_display_overlay', 'single_panel_page', 'diplay_overlay'];
+      ['adapt_display_overlay', 'single_panel_page', 'diplay_overlay'];
 
   // Items corresponding to flex boxes
   const flexItems = [
@@ -676,8 +676,8 @@ function showHideItems() {
 
   // Concatenation of all items
   const fullItems = libraryItems.concat(
-    websiteItems, designItems, designValidItems, designValidTimeItems,
-    saveItems, displayItems);
+      websiteItems, designItems, designValidItems, designValidTimeItems,
+      saveItems, displayItems);
 
   // Loop on all the items
   for (const itemName of fullItems) {
@@ -727,7 +727,7 @@ function showHideItems() {
 
     if (showItem) {  // Valid BO -> show items
       document.getElementById(itemName).style.display =
-        flexItems.includes(itemName) ? 'flex' : 'block';
+          flexItems.includes(itemName) ? 'flex' : 'block';
     } else {  // Invalid BO -> hide items
       document.getElementById(itemName).style.display = 'none';
     }
@@ -783,7 +783,7 @@ function updateDataBO() {
 
   // Display success/error message
   document.getElementById('bo_validity_message').textContent =
-    BOValidityMessage;
+      BOValidityMessage;
 
   if (!validBO) {  // BO is not valid
     updateInvalidDataBO();
@@ -815,7 +815,7 @@ function updateImagesSelection(subFolder) {
   // Maximum number of images per row
   let maxRowCount = MAX_ROW_SELECT_IMAGES;
   if ((gameName in SPECIAL_MAX_ROW_SELECT_IMAGES) &&
-    (subFolder in SPECIAL_MAX_ROW_SELECT_IMAGES[gameName])) {
+      (subFolder in SPECIAL_MAX_ROW_SELECT_IMAGES[gameName])) {
     maxRowCount = SPECIAL_MAX_ROW_SELECT_IMAGES[gameName][subFolder];
   }
 
@@ -823,7 +823,7 @@ function updateImagesSelection(subFolder) {
   if (subFolder === 'select faction') {
     for (const [key, value] of Object.entries(factionsList)) {
       console.assert(
-        value.length === 2, 'Faction list item should have a size of 2');
+          value.length === 2, 'Faction list item should have a size of 2');
 
       // Check if it is a valid image and get its path
       const imagePath = getImagePath(factionImagesFolder + '/' + value[1]);
@@ -832,7 +832,7 @@ function updateImagesSelection(subFolder) {
           imagesContent += '<div class="row">';  // start new row
         }
         imagesContent += getImageHTML(
-          imagePath, SELECT_IMAGE_HEIGHT, 'updateImageCopyClipboard', key);
+            imagePath, SELECT_IMAGE_HEIGHT, 'updateImageCopyClipboard', key);
 
         // Each row can have a maximum of images
         rowCount++;
@@ -856,8 +856,8 @@ function updateImagesSelection(subFolder) {
         }
         const imageWithSubFolder = '@' + subFolder + '/' + image + '@';
         imagesContent += getImageHTML(
-          imagePath, SELECT_IMAGE_HEIGHT, 'updateImageCopyClipboard',
-          imageWithSubFolder);
+            imagePath, SELECT_IMAGE_HEIGHT, 'updateImageCopyClipboard',
+            imageWithSubFolder);
 
         // Each row can have a maximum of images
         rowCount++;
@@ -887,15 +887,15 @@ function initBOFactionSelection() {
 
   // Filter on player faction, then on opponent faction
   for (const widgetID
-    of ['bo_faction_select_widget',
-      'bo_opponent_faction_select_widget']) {
+           of ['bo_faction_select_widget',
+               'bo_opponent_faction_select_widget']) {
     // Widget to select the faction (for BOs filtering)
     let factionSelectWidget = document.getElementById(widgetID);
     factionSelectWidget.innerHTML = null;  // Clear all options
 
     // Skip if no opponent faction filtering
     if ((widgetID === 'bo_opponent_faction_select_widget') &&
-      !FACTION_FIELD_NAMES[gameName]['opponent']) {
+        !FACTION_FIELD_NAMES[gameName]['opponent']) {
       factionSelectWidget.style.display = 'none';
     }
     // Display faction filtering
@@ -903,13 +903,13 @@ function initBOFactionSelection() {
       factionSelectWidget.style.display = 'block';
 
       console.assert(
-        Object.keys(factionsList).length >= 1,
-        'At least one faction expected.');
+          Object.keys(factionsList).length >= 1,
+          'At least one faction expected.');
       // Loop on all the factions
       for (const [factionName, shortAndImage] of Object.entries(factionsList)) {
         console.assert(
-          shortAndImage.length === 2,
-          '\'shortAndImage\' should have a size of 2');
+            shortAndImage.length === 2,
+            '\'shortAndImage\' should have a size of 2');
 
         let option = document.createElement('option');
         option.text = shortAndImage[0];
@@ -930,7 +930,7 @@ function updateFactionImageSelection() {
   // Filter on player faction, then on opponent faction
   for (let i = 0; i < 2; i++) {
     let factionImage = document.getElementById(
-      (i === 0) ? 'bo_faction_image' : 'bo_opponent_faction_image');
+        (i === 0) ? 'bo_faction_image' : 'bo_opponent_faction_image');
 
     // Skip if no opponent faction filtering
     if ((i === 1) && !FACTION_FIELD_NAMES[gameName]['opponent']) {
@@ -939,15 +939,15 @@ function updateFactionImageSelection() {
       factionImage.style.display = 'block';
 
       const widgetName = (i === 0) ? 'bo_faction_select_widget' :
-        'bo_opponent_faction_select_widget';
+                                     'bo_opponent_faction_select_widget';
       const shortAndImage =
-        factionsList[document.getElementById(widgetName).value];
+          factionsList[document.getElementById(widgetName).value];
       console.assert(
-        shortAndImage.length === 2,
-        '\'shortAndImage\' should have a size of 2');
+          shortAndImage.length === 2,
+          '\'shortAndImage\' should have a size of 2');
       factionImage.innerHTML = getImageHTML(
-        getImagePath(factionImagesFolder + '/' + shortAndImage[1]),
-        FACTION_ICON_HEIGHT);
+          getImagePath(factionImagesFolder + '/' + shortAndImage[1]),
+          FACTION_ICON_HEIGHT);
     }
   }
 }
@@ -987,21 +987,21 @@ function initImagesSelection() {
  */
 function updateMainConfigSelection() {
   const fromLibrary =
-    '<input type="radio" id="config_library" name="main_config_radios" value="library" checked>' +
-    '<label for="config_library" class="button">From library</label>';
+      '<input type="radio" id="config_library" name="main_config_radios" value="library" checked>' +
+      '<label for="config_library" class="button">From library</label>';
 
   const fromWebsite =
-    '<input type="radio" id="config_website" name="main_config_radios" value="website">' +
-    '<label for="config_website" class="button">From external website</label>';
+      '<input type="radio" id="config_website" name="main_config_radios" value="website">' +
+      '<label for="config_website" class="button">From external website</label>';
 
   const designYourOwn =
-    '<input type="radio" id="config_design" name="main_config_radios" value="design">' +
-    '<label for="config_design" class="button">Design your own</label>';
+      '<input type="radio" id="config_design" name="main_config_radios" value="design">' +
+      '<label for="config_design" class="button">Design your own</label>';
 
   // Add or not the website section (checking if there is at least one website).
   const fullContent = (gameName in EXTERNAL_BO_WEBSITES) ?
-    fromLibrary + fromWebsite + designYourOwn :
-    fromLibrary + designYourOwn;
+      fromLibrary + fromWebsite + designYourOwn :
+      fromLibrary + designYourOwn;
 
   document.getElementById('main_configuration').innerHTML = fullContent;
 
@@ -1012,7 +1012,7 @@ function updateMainConfigSelection() {
   // Updating when selecting another configuration
   let radios = document.querySelectorAll('input[name="main_config_radios"]');
   for (let i = 0; i < radios.length; i++) {
-    radios[i].addEventListener('change', function () {
+    radios[i].addEventListener('change', function() {
       mainConfiguration = this.value;
       showHideItems();
     });
@@ -1030,22 +1030,22 @@ function updateExternalBOWebsites() {
     // Add links to all websites
     for (const entry of EXTERNAL_BO_WEBSITES[gameName]) {
       console.assert(
-        entry.length === 3,
-        'All entries in \'EXTERNAL_BO_WEBSITES\' must have a size of 3.');
+          entry.length === 3,
+          'All entries in \'EXTERNAL_BO_WEBSITES\' must have a size of 3.');
       linksContent +=
-        '<form action="' + entry[1] + '" target="_blank" class="tooltip">';
+          '<form action="' + entry[1] + '" target="_blank" class="tooltip">';
       linksContent +=
-        '<input class="button" type="submit" value="' + entry[0] + '" />';
+          '<input class="button" type="submit" value="' + entry[0] + '" />';
       linksContent += '<span class="tooltiptext_right">';
       linksContent +=
-        '<div>External build order website providing build orders with RTS Overlay format.</div>';
+          '<div>External build order website providing build orders with RTS Overlay format.</div>';
       linksContent += '-----';
       linksContent += '<div>To import the requested build order:</div>';
       linksContent +=
-        '<div>1. Select the requested build order on ' + entry[0] + '.</div>';
+          '<div>1. Select the requested build order on ' + entry[0] + '.</div>';
       linksContent += '<div>2. ' + entry[2] + '</div>';
       linksContent +=
-        '<div>3. Paste the clipboard content on the right panel.</div>';
+          '<div>3. Paste the clipboard content on the right panel.</div>';
       linksContent += '</span>';
       linksContent += '</form>';
     }
@@ -1133,8 +1133,8 @@ function getDiplayOverlayTooltiptext() {
 function updateBOFromWidgets() {
   // Font size
   const fontSize = parseFloat(document.getElementById('bo_fontsize').value)
-    .toFixed(1)
-    .toString();
+                       .toFixed(1)
+                       .toString();
   document.getElementById('bo_fontsize_value').innerHTML = fontSize + ' (font)';
 
   let boPanelElement = document.getElementById('bo_panel');
@@ -1143,7 +1143,7 @@ function updateBOFromWidgets() {
   // Images size
   const imagesSize = parseInt(document.getElementById('bo_images_size').value);
   document.getElementById('bo_images_size_value').innerHTML =
-    imagesSize + ' (images)';
+      imagesSize + ' (images)';
 
   if (imagesSize !== imageHeightBO) {
     imageHeightBO = imagesSize;
@@ -1153,11 +1153,11 @@ function updateBOFromWidgets() {
 
   // Fixed top corner choice
   const newOverlayOnRightSide =
-    document.getElementById('left_right_side').checked;
+      document.getElementById('left_right_side').checked;
   if (newOverlayOnRightSide !== overlayOnRightSide) {
     overlayOnRightSide = newOverlayOnRightSide;
     document.getElementById('side_selection_text').innerHTML =
-      'overlay on the ' + (overlayOnRightSide ? 'right' : 'left');
+        'overlay on the ' + (overlayOnRightSide ? 'right' : 'left');
     updateBOPanel(false);
   }
 }
@@ -1179,7 +1179,7 @@ function updateGameWithName(newGameName) {
       gameName = newGameName;
       gameFullName = selectGame.options[i].text;
 
-      updateGame(); // Update the other variables
+      updateGame();  // Update the other variables
       return true;
     }
   }
@@ -1244,21 +1244,21 @@ function initConfigWindow() {
 
   // Update the hotkeys tooltip for 'Diplay overlay'
   document.getElementById('diplay_overlay_tooltiptext').innerHTML =
-    getDiplayOverlayTooltiptext();
+      getDiplayOverlayTooltiptext();
 
   // Set default sliders values
   document.getElementById('bo_fontsize').value = DEFAULT_BO_PANEL_FONTSIZE;
   document.getElementById('bo_images_size').value =
-    DEFAULT_BO_PANEL_IMAGES_SIZE;
+      DEFAULT_BO_PANEL_IMAGES_SIZE;
   document.getElementById('left_right_side').checked =
-    DEFAULT_OVERLAY_ON_RIGHT_SIDE;
+      DEFAULT_OVERLAY_ON_RIGHT_SIDE;
   updateBOFromWidgets();
 
   // Update elements depending on the selected game
   updateGame();
 
   // Updating the variables when changing the game
-  document.getElementById('select_game').addEventListener('input', function () {
+  document.getElementById('select_game').addEventListener('input', function() {
     const selectGame = document.getElementById('select_game');
     gameName = selectGame.value;
     gameFullName = selectGame.options[selectGame.selectedIndex].text;
@@ -1267,53 +1267,53 @@ function initConfigWindow() {
   });
 
   // Panel is automatically updated when the BO design panel is changed
-  document.getElementById('bo_design').addEventListener('input', function () {
+  document.getElementById('bo_design').addEventListener('input', function() {
     updateDataBO();
     updateBOPanel(false);
   });
 
   // Update the selection images each time a new category is selected
   document.getElementById('image_class_selection')
-    .addEventListener('input', function () {
-      updateImagesSelection(
-        document.getElementById('image_class_selection').value);
-    });
+      .addEventListener('input', function() {
+        updateImagesSelection(
+            document.getElementById('image_class_selection').value);
+      });
 
   // Update BO elements when any slider is moving
-  document.getElementById('bo_fontsize').addEventListener('input', function () {
+  document.getElementById('bo_fontsize').addEventListener('input', function() {
     updateBOFromWidgets();
   });
 
   document.getElementById('bo_images_size')
-    .addEventListener('input', function () {
-      updateBOFromWidgets();
-    });
+      .addEventListener('input', function() {
+        updateBOFromWidgets();
+      });
 
   // Update BO side selection when updating the corresponding toggle
   document.getElementById('left_right_side')
-    .addEventListener('input', function () {
-      updateBOFromWidgets();
-    });
+      .addEventListener('input', function() {
+        updateBOFromWidgets();
+      });
 
   // Update the library search for each new input or faction selection
   document.getElementById('bo_faction_text')
-    .addEventListener('input', function () {
-      updateLibrarySearch();
-    });
+      .addEventListener('input', function() {
+        updateLibrarySearch();
+      });
 
   document.getElementById('bo_faction_select_widget')
-    .addEventListener('input', function () {
-      updateFactionImageSelection();
-      updateLibraryValidKeys();
-      updateLibrarySearch();
-    });
+      .addEventListener('input', function() {
+        updateFactionImageSelection();
+        updateLibraryValidKeys();
+        updateLibrarySearch();
+      });
 
   document.getElementById('bo_opponent_faction_select_widget')
-    .addEventListener('input', function () {
-      updateFactionImageSelection();
-      updateLibraryValidKeys();
-      updateLibrarySearch();
-    });
+      .addEventListener('input', function() {
+        updateFactionImageSelection();
+        updateLibraryValidKeys();
+        updateLibrarySearch();
+      });
 }
 
 /**
@@ -1321,7 +1321,7 @@ function initConfigWindow() {
  */
 function updateTitle() {
   document.getElementById('rts_overlay_title').innerHTML =
-    getImageHTML('assets/common/title/rts_overlay.png', TITLE_IMAGE_HEIGHT);
+      getImageHTML('assets/common/title/rts_overlay.png', TITLE_IMAGE_HEIGHT);
 }
 
 /**
@@ -1329,10 +1329,10 @@ function updateTitle() {
  */
 function updateRTSOverlayInfo() {
   let content = '<div>' +
-    getImageHTML('assets/common/icon/info.png', INFO_IMAGE_HEIGHT) + '</div>';
+      getImageHTML('assets/common/icon/info.png', INFO_IMAGE_HEIGHT) + '</div>';
   content +=
-    '<span id="tooltip_rts_overlay_info" class="tooltiptext_left"><div>' +
-    getInstructions() + '</div></span>';
+      '<span id="tooltip_rts_overlay_info" class="tooltiptext_left"><div>' +
+      getInstructions() + '</div></span>';
 
   document.getElementById('rts_overlay_info').innerHTML = content;
 }
@@ -1345,8 +1345,8 @@ function updateSalamanderIcon() {
   document.getElementById('bo_panel_sliders').style.display = 'none';
   document.getElementById('left_right_toggle').style.display = 'none';
   document.getElementById('salamander').innerHTML = getImageHTML(
-    'assets/common/icon/salamander_sword_shield.png',
-    SALAMANDER_IMAGE_HEIGHT);
+      'assets/common/icon/salamander_sword_shield.png',
+      SALAMANDER_IMAGE_HEIGHT);
 }
 
 /**
@@ -1375,7 +1375,7 @@ function updateBOPanel(overlayFlag) {
 
   // Update BO content
   document.getElementById('bo_panel').innerHTML =
-    getBOPanelContent(overlayFlag, stepID);
+      getBOPanelContent(overlayFlag, stepID);
 
   // Updates for the overlay BO panel
   if (overlayFlag) {
@@ -1393,7 +1393,7 @@ function updateBOPanel(overlayFlag) {
  */
 function initOverlayWindow() {
   // Using hotkeys to interact with the overlay
-  document.addEventListener('keydown', function (event) {
+  document.addEventListener('keydown', function(event) {
     const code = event.code;
     if (code !== '') {
       switch (code) {
@@ -1442,9 +1442,9 @@ function getImagesCommon() {
   // This is obtained using the 'python/utilities/list_images.py' script.
   let imagesDict = {
     'action_button':
-      'feather.png#gears.png#leave.png#load.png#manual_timer_switch.png#next.png#pause.png#previous.png#save.png#start_stop.png#start_stop_active.png#timer_0.png#to_beginning.png#to_end.png',
+        'feather.png#gears.png#leave.png#load.png#manual_timer_switch.png#next.png#pause.png#previous.png#save.png#start_stop.png#start_stop_active.png#timer_0.png#to_beginning.png#to_end.png',
     'icon':
-      'house.png#mouse.png#question_mark.png#salamander_sword_shield.png#time.png'
+        'house.png#mouse.png#question_mark.png#salamander_sword_shield.png#time.png'
   };
 
   // Split each string (e.g. 'image_0#image_1#image_2') in a list of images.
@@ -1475,12 +1475,12 @@ function checkBuildOrderKeyValues(buildOrder, keyCondition = null) {
       const dataCheck = buildOrder[key];
       // Any build order data value is valid
       if (['any', 'Any', 'Generic'].includes(dataCheck) ||
-        ['any', 'Any'].includes(target)) {
+          ['any', 'Any'].includes(target)) {
         continue;
       }
       const isArray = Array.isArray(dataCheck);
       if ((isArray && (!dataCheck.includes(target))) ||
-        (!isArray && (target !== dataCheck))) {
+          (!isArray && (target !== dataCheck))) {
         return false;  // at least one key condition not met
       }
     }
@@ -1506,7 +1506,7 @@ function checkBuildOrderKeyValues(buildOrder, keyCondition = null) {
  * @returns Updated note (potentially with illustration).
  */
 function convertTXTNoteToIllustrated(
-  note, convertDict, toLower = false, maxSize = -1, ignoreInDict = null) {
+    note, convertDict, toLower = false, maxSize = -1, ignoreInDict = null) {
   const noteSplit = note.split(' ');    // note split based on spaces
   const splitCount = noteSplit.length;  // number of elements in the split
 
@@ -1526,24 +1526,24 @@ function convertTXTNoteToIllustrated(
     // number of gather sets that can be made
     const setCount = splitCount - gatherCount + 1;
     console.assert(
-      1 <= setCount && setCount <= splitCount, 'setCount value not correct.');
+        1 <= setCount && setCount <= splitCount, 'setCount value not correct.');
 
     // ID of the first element
     for (let firstID = 0; firstID < setCount; firstID++) {
       console.assert(
-        0 <= firstID && firstID < splitCount, 'firstID value not correct.');
+          0 <= firstID && firstID < splitCount, 'firstID value not correct.');
       let checkNote = noteSplit[firstID];
 
       for (let nextElemID = firstID + 1; nextElemID < firstID + gatherCount;
-        nextElemID++) {  // gather the next elements
+           nextElemID++) {  // gather the next elements
         console.assert(
-          1 <= nextElemID && nextElemID < splitCount,
-          'nextElemID not correct.');
+            1 <= nextElemID && nextElemID < splitCount,
+            'nextElemID not correct.');
         checkNote += ' ' + noteSplit[nextElemID];
       }
 
       let updatedCheckNote =
-        checkNote.slice(0);  // update based on requests (slice for copy)
+          checkNote.slice(0);  // update based on requests (slice for copy)
 
       for (const ignoreElem of ignoreInDict) {  // ignore parts in dictionary
         updatedCheckNote = updatedCheckNote.replaceAll(ignoreElem, '');
@@ -1573,7 +1573,7 @@ function convertTXTNoteToIllustrated(
 
           // Get back ignored parts (after dictionary replace)
           for (let characterID = checkNoteLen - 1; characterID >= 0;
-            characterID--) {
+               characterID--) {
             if (ignoreInDict.includes(checkNote[characterID])) {
               ignoreAfter += checkNote[characterID];
             } else {
@@ -1590,8 +1590,8 @@ function convertTXTNoteToIllustrated(
         let beforeNote = '';
         for (let beforeID = 0; beforeID < firstID; beforeID++) {
           console.assert(
-            0 <= beforeID && beforeID < splitCount,
-            'beforeID value not correct.');
+              0 <= beforeID && beforeID < splitCount,
+              'beforeID value not correct.');
           beforeNote += ' ' + noteSplit[beforeID];
         }
         beforeNote = beforeNote.replaceAll(/^\s+/gm, '');  // lstrip in Python
@@ -1599,10 +1599,10 @@ function convertTXTNoteToIllustrated(
         // Gather note parts after the found sub-note
         let afterNote = '';
         for (let afterID = firstID + gatherCount; afterID < splitCount;
-          afterID++) {
+             afterID++) {
           console.assert(
-            0 <= afterID && afterID < splitCount,
-            'afterID value not correct.');
+              0 <= afterID && afterID < splitCount,
+              'afterID value not correct.');
           afterNote += ' ' + noteSplit[afterID];
         }
         afterNote = afterNote.replaceAll(/^\s+/gm, '');  // lstrip in Python
@@ -1611,19 +1611,19 @@ function convertTXTNoteToIllustrated(
         let finalNote = '';
         if (beforeNote !== '') {
           finalNote +=
-            convertTXTNoteToIllustrated(
-              beforeNote, convertDict, toLower, maxSize, ignoreInDict) +
-            ' ';
+              convertTXTNoteToIllustrated(
+                  beforeNote, convertDict, toLower, maxSize, ignoreInDict) +
+              ' ';
         }
 
         finalNote += ignoreBefore + '@' + convertDict[updatedCheckNote] + '@' +
-          ignoreAfter;
+            ignoreAfter;
 
         if (afterNote !== '') {
           finalNote +=
-            ' ' +
-            convertTXTNoteToIllustrated(
-              afterNote, convertDict, toLower, maxSize, ignoreInDict);
+              ' ' +
+              convertTXTNoteToIllustrated(
+                  afterNote, convertDict, toLower, maxSize, ignoreInDict);
         }
 
         return finalNote;
@@ -1649,7 +1649,7 @@ function buildOrderTimeToStr(timeSec) {
   }
 
   return Math.floor(timeSec / 60).toString() + ':' +
-    ('0' + (timeSec % 60).toString()).slice(-2);
+      ('0' + (timeSec % 60).toString()).slice(-2);
 }
 
 /**
@@ -1792,7 +1792,7 @@ function getBuildOrderTimerStepIDs(steps, currentTimeSec, startingFlag = true) {
   for (const currentStepID of stepRange) {
     const step = steps[currentStepID];
     if ((startingFlag && (currentTimeSec >= step['time_sec'])) ||
-      (!startingFlag && (currentTimeSec <= step['time_sec']))) {
+        (!startingFlag && (currentTimeSec <= step['time_sec']))) {
       if (step['time_sec'] !== lastTimeSec) {
         selectedIDs = [currentStepID];
         lastTimeSec = step['time_sec'];
@@ -1823,7 +1823,7 @@ function getBuildOrderTimerStepsDisplay(steps, stepIDs) {
   console.assert(stepIDs.length > 0, 'stepIDs must be > 0.');
   for (const stepID of stepIDs) {
     console.assert(
-      0 <= stepID && stepID < steps.length, 'Invalid value for stepID.');
+        0 <= stepID && stepID < steps.length, 'Invalid value for stepID.');
   }
   stepIDs.sort();  // safety (should already be the case)
 
@@ -1850,8 +1850,8 @@ function getBuildOrderTimerStepsDisplay(steps, stepIDs) {
   const finalID = Math.min(steps.length, stepIDs.at(-1) + 2);
 
   console.assert(
-    0 <= initID && initID < finalID && finalID <= steps.length,
-    'Invalid values for initID and/or finalID.');
+      0 <= initID && initID < finalID && finalID <= steps.length,
+      'Invalid values for initID and/or finalID.');
 
   const outSteps = steps.slice(initID, finalID);
   let outStepIDs = [];
@@ -1863,8 +1863,8 @@ function getBuildOrderTimerStepsDisplay(steps, stepIDs) {
   }
 
   console.assert(
-    (outStepIDs.length > 0) && (outSteps.length > 0),
-    'Wrong size for the selected steps and/or IDs');
+      (outStepIDs.length > 0) && (outSteps.length > 0),
+      'Wrong size for the selected steps and/or IDs');
   return [outStepIDs, outSteps];
 }
 
@@ -1884,7 +1884,7 @@ function switchBuildOrderTimerManual() {
 
     // Select current step
     if (!buildOrderTimer['use_timer'] &&
-      (buildOrderTimer['steps_ids'].length > 0)) {
+        (buildOrderTimer['steps_ids'].length > 0)) {
       stepID = buildOrderTimer['steps_ids'][0];
     }
 
@@ -1901,8 +1901,8 @@ function updateBuildOrderStartStopTimerIcon() {
   let elem = document.getElementById('start_stop_timer');
   if (elem) {
     elem.src = 'assets/common/action_button/' +
-      (buildOrderTimer['run_timer'] ? 'start_stop_active.png' :
-        'start_stop.png');
+        (buildOrderTimer['run_timer'] ? 'start_stop_active.png' :
+                                        'start_stop.png');
   }
 }
 
@@ -1918,7 +1918,7 @@ function startStopBuildOrderTimer(invertRun = true, runValue = true) {
     const newRunState = invertRun ? (!buildOrderTimer['run_timer']) : runValue;
 
     if (newRunState !==
-      buildOrderTimer['run_timer']) {  // only update if change
+        buildOrderTimer['run_timer']) {  // only update if change
       buildOrderTimer['run_timer'] = newRunState;
 
       // Time
@@ -1960,7 +1960,7 @@ function getBuildOrderSelectedStepsAndIDs(BOStepID) {
   if (buildOrderTimer['use_timer'] && buildOrderTimer['steps'].length > 0) {
     // Get steps to display
     return getBuildOrderTimerStepsDisplay(
-      buildOrderTimer['steps'], buildOrderTimer['steps_ids']);
+        buildOrderTimer['steps'], buildOrderTimer['steps_ids']);
   } else {
     const buildOrderData = dataBO['build_order'];
 
@@ -1970,8 +1970,8 @@ function getBuildOrderSelectedStepsAndIDs(BOStepID) {
     const selectedSteps = [buildOrderData[BOStepID]];
     console.assert(selectedSteps[0] !== null, 'Selected steps are not valid');
     console.assert(
-      (selectedSteps.length > 0) && (selectedStepsIDs.length > 0),
-      'Wrong size for the selected steps and/or IDs');
+        (selectedSteps.length > 0) && (selectedStepsIDs.length > 0),
+        'Wrong size for the selected steps and/or IDs');
     return [selectedStepsIDs, selectedSteps];
   }
 }
@@ -2018,16 +2018,16 @@ function checkValidFaction(BONameStr, factionName, requested, anyValid = true) {
     if (Array.isArray(factionData)) {  // List of factions
       if (factionData.length === 0) {
         return invalidMsg(
-          BONameStr + 'Valid "' + factionName + '" list is empty.');
+            BONameStr + 'Valid "' + factionName + '" list is empty.');
       }
 
       for (const faction of factionData) {  // Loop on the provided factions
         const anyFlag = ['any', 'Any'].includes(faction);
         if (!(!anyFlag && (faction in factionsList)) &&
-          !(anyFlag && anyValid)) {
+            !(anyFlag && anyValid)) {
           return invalidMsg(
-            BONameStr + 'Unknown ' + factionName + ' "' + faction +
-            '" (check spelling).');
+              BONameStr + 'Unknown ' + factionName + ' "' + faction +
+              '" (check spelling).');
         }
       }
     }
@@ -2035,10 +2035,10 @@ function checkValidFaction(BONameStr, factionName, requested, anyValid = true) {
     else {
       const anyFlag = ['any', 'Any'].includes(factionData);
       if (!(!anyFlag && (factionData in factionsList)) &&
-        !(anyFlag && anyValid)) {
+          !(anyFlag && anyValid)) {
         return invalidMsg(
-          BONameStr + 'Unknown ' + factionName + ' "' + factionData +
-          '" (check spelling).');
+            BONameStr + 'Unknown ' + factionName + ' "' + factionData +
+            '" (check spelling).');
       }
     }
   }
@@ -2068,7 +2068,7 @@ class FieldDefinition {
   constructor(name, type, requested, parentName = null, validRange = null) {
     // Check input types
     if (typeof name !== 'string' || typeof type !== 'string' ||
-      (parentName && typeof parentName !== 'string')) {
+        (parentName && typeof parentName !== 'string')) {
       throw 'FieldDefinition expected strings for \'name\', \'type\' and \'parentName\'.';
     }
 
@@ -2131,7 +2131,7 @@ class FieldDefinition {
   checkRange(value) {
     // Check only needed for integer values with defined range
     if (this.type !== 'integer' || !Number.isInteger(value) ||
-      !this.validRange) {
+        !this.validRange) {
       return true;
     }
 
@@ -2150,13 +2150,13 @@ class FieldDefinition {
   check(value) {
     if (!this.checkType(value)) {
       return invalidMsg(
-        'Wrong value (' + value + '), expected ' + this.type + ' type.');
+          'Wrong value (' + value + '), expected ' + this.type + ' type.');
     }
 
     if (!this.checkRange(value)) {
       return invalidMsg(
-        'Wrong value (' + value + '), must be in [' + this.validRange[0] +
-        ' ; ' + this.validRange[1] + '] range.');
+          'Wrong value (' + value + '), must be in [' + this.validRange[0] +
+          ' ; ' + this.validRange[1] + '] range.');
     }
 
     return validMsg();
@@ -2197,7 +2197,7 @@ function checkValidSteps(BONameStr, fields) {
   for (const [stepID, step] of enumerate(buildOrderData)) {
     // Prefix before error message
     const prefixMsg = BONameStr + 'Step ' + (stepID + 1).toString() + '/' +
-      buildOrderData.length + ' | ';
+        buildOrderData.length + ' | ';
 
     // Loop on all the step fields
     for (const field of fields) {
@@ -2212,21 +2212,21 @@ function checkValidSteps(BONameStr, fields) {
             const res = field.check(step[field.parentName][field.name]);
             if (!res[0]) {
               return invalidMsg(
-                prefixMsg + '"' + field.parentName + '/' + field.name +
-                '" | ' + res[1]);
+                  prefixMsg + '"' + field.parentName + '/' + field.name +
+                  '" | ' + res[1]);
             }
           }
           // Child field is missing
           else if (field.requested) {
             return invalidMsg(
-              prefixMsg + 'Missing field: "' + field.parentName + '/' +
-              field.name + '".');
+                prefixMsg + 'Missing field: "' + field.parentName + '/' +
+                field.name + '".');
           }
         }
         // Parent field missing
         else if (field.requested) {
           return invalidMsg(
-            prefixMsg + 'Missing field: "' + field.parentName + '".');
+              prefixMsg + 'Missing field: "' + field.parentName + '".');
         }
       }
       // Not present in a parent
@@ -2257,7 +2257,7 @@ function evaluateTime() {
 
     // Update text editing space
     document.getElementById('bo_design').value =
-      JSON.stringify(dataBO, null, 4);
+        JSON.stringify(dataBO, null, 4);
 
     // Update BO and panel
     updateDataBO();
@@ -2302,23 +2302,23 @@ function timerBuildOrderCall() {
       elapsedTime *= buildOrderTimer['timer_speed_factor'];
     }
     buildOrderTimer['time_sec'] =
-      buildOrderTimer['time_sec_init'] + elapsedTime;
+        buildOrderTimer['time_sec_init'] + elapsedTime;
     buildOrderTimer['time_int'] = Math.floor(buildOrderTimer['time_sec']);
 
     // Time was updated (or no valid note IDs)
     if ((buildOrderTimer['last_time_int'] !== buildOrderTimer['time_int']) ||
-      (buildOrderTimer['last_steps_ids'].length === 0)) {
+        (buildOrderTimer['last_steps_ids'].length === 0)) {
       buildOrderTimer['last_time_int'] = buildOrderTimer['time_int'];
 
       // Compute current note IDs
       buildOrderTimer['steps_ids'] = getBuildOrderTimerStepIDs(
-        buildOrderTimer['steps'], buildOrderTimer['time_int'],
-        buildOrderTimer['step_starting_flag']);
+          buildOrderTimer['steps'], buildOrderTimer['time_int'],
+          buildOrderTimer['step_starting_flag']);
 
       // Note IDs were updated
       if (buildOrderTimer['last_steps_ids'] !== buildOrderTimer['steps_ids']) {
         buildOrderTimer['last_steps_ids'] =
-          buildOrderTimer['steps_ids'].slice();  // slice for copy
+            buildOrderTimer['steps_ids'].slice();  // slice for copy
         updateBOPanel(true);
       }
     }
@@ -2331,7 +2331,7 @@ function timerBuildOrderCall() {
 function formatBuildOrder() {
   if (dataBO) {
     document.getElementById('bo_design').value =
-      JSON.stringify(dataBO, null, 4);
+        JSON.stringify(dataBO, null, 4);
     updateDataBO();
     updateBOPanel(false);
   }
@@ -2379,7 +2379,7 @@ function BODesignDropHandler(ev) {
 
   // Use file content for 'bo_design' text area
   let reader = new FileReader();
-  reader.onload = function (e) {
+  reader.onload = function(e) {
     bo_design.value = e.target.result;
     updateDataBO();
     updateBOPanel(false);
@@ -2400,7 +2400,7 @@ function saveBOToFile(data = null) {
   }
 
   // Create a file with the BO content
-  const file = new Blob([JSON.stringify(data, null, 4)], { type: 'text/plain' });
+  const file = new Blob([JSON.stringify(data, null, 4)], {type: 'text/plain'});
 
   // Add file content in an object URL with <a> tag
   const link = document.createElement('a');
@@ -2435,8 +2435,8 @@ function deleteSelectedBO() {
   }
 
   const text = 'Are you sure you want to delete the build order \'' +
-    selectedBOFromLibrary + '\' (' + gameFullName +
-    ') from your local storage?\nThis cannot be undone.';
+      selectedBOFromLibrary + '\' (' + gameFullName +
+      ') from your local storage?\nThis cannot be undone.';
   if (confirm(text)) {
     localStorage.removeItem(keyName);
     readLibrary();
@@ -2450,8 +2450,8 @@ function deleteSelectedBO() {
  */
 function deleteAllBOs() {
   const text = 'Are you sure you want to delete ALL BUILD ORDERS (from ' +
-    gameFullName + ') from your local storage?' +
-    '\nThis cannot be undone.';
+      gameFullName + ') from your local storage?' +
+      '\nThis cannot be undone.';
 
   if (confirm(text)) {
     const gamePrefix = gameName + '|';
@@ -2498,14 +2498,14 @@ function addToLocalStorage() {
 
     if (localStorage.getItem(keyName)) {
       const text = 'There is already a build order with name \'' +
-        dataBO['name'] + '\' for ' + gameFullName +
-        '.\nDo you want to replace it with your new build order?';
+          dataBO['name'] + '\' for ' + gameFullName +
+          '.\nDo you want to replace it with your new build order?';
       if (!confirm(text)) {
         return;
       }
     } else {
       const text = 'Do you want to save your build order with name \'' +
-        dataBO['name'] + '\' for ' + gameFullName + '?';
+          dataBO['name'] + '\' for ' + gameFullName + '?';
       if (!confirm(text)) {
         return;
       }
@@ -2515,8 +2515,8 @@ function addToLocalStorage() {
     readLibrary();
     updateLibrarySearch();
     alert(
-      'Build order saved with key name \'' + keyName +
-      '\' in local storage.');
+        'Build order saved with key name \'' + keyName +
+        '\' in local storage.');
 
   } else {
     alert('Build order is not valid. It cannot be saved.');
@@ -2554,8 +2554,8 @@ function computeLevenshtein(strA, strB) {
         matrix[i][j] = matrix[i - 1][j - 1];
       } else {
         matrix[i][j] = Math.min(
-          matrix[i - 1][j] + 1, matrix[i][j - 1] + 1,
-          matrix[i - 1][j - 1] + 1);
+            matrix[i - 1][j] + 1, matrix[i][j - 1] + 1,
+            matrix[i - 1][j - 1] + 1);
       }
     }
   }
@@ -2578,7 +2578,7 @@ function computeSameSizeLevenshtein(strSmall, strLarge) {
   const lenSmall = strSmall.length;
   const lenLarge = strLarge.length;
   console.assert(
-    lenSmall <= lenLarge, '\'strSmall\' must be smaller than \'strLarge\'.');
+      lenSmall <= lenLarge, '\'strSmall\' must be smaller than \'strLarge\'.');
 
   // Normal Levenshtein computation is same size
   if (lenSmall === lenLarge) {
@@ -2596,7 +2596,7 @@ function computeSameSizeLevenshtein(strSmall, strLarge) {
 
   for (let i = 1; i <= maxId; i++) {
     const currentScore =
-      computeLevenshtein(strSmall, strLarge.slice(i, i + lenSmall));
+        computeLevenshtein(strSmall, strLarge.slice(i, i + lenSmall));
     if (currentScore === 1) {  // Cannot be smaller than 1 if not included
       return 1;
     } else if (currentScore < minScore) {
@@ -2680,11 +2680,11 @@ function getKeyCondition() {
   let keyCondition = {};
   if (playerFactionName) {
     keyCondition[playerFactionName] =
-      document.getElementById('bo_faction_select_widget').value;
+        document.getElementById('bo_faction_select_widget').value;
   }
   if (opponentFactionName) {
     keyCondition[opponentFactionName] =
-      document.getElementById('bo_opponent_faction_select_widget').value;
+        document.getElementById('bo_opponent_faction_select_widget').value;
   }
 
   return keyCondition;
@@ -2760,7 +2760,7 @@ function compareLibraryFaction(keyCondition, itemA, itemB) {
 function clearSearchResultSelect() {
   let elements = document.getElementsByClassName('search_key_line');
 
-  Array.prototype.forEach.call(elements, function (el) {
+  Array.prototype.forEach.call(elements, function(el) {
     document.getElementById(el.id).classList.remove('search_key_select');
   });
 }
@@ -2774,7 +2774,7 @@ function mouseOverSearchResult(id) {
   clearSearchResultSelect();
 
   document.getElementById('search_key_line_' + id)
-    .classList.add('search_key_select');
+      .classList.add('search_key_select');
 }
 
 /**
@@ -2793,9 +2793,9 @@ function mouseClickSearchResult(key) {
 
   // Update build order search lines
   let boSearchText =
-    '<div " class="search_key_line">Selected build order:</div>';
+      '<div " class="search_key_line">Selected build order:</div>';
   boSearchText +=
-    '<div " class="search_key_line search_key_select">' + key + '</div>';
+      '<div " class="search_key_line search_key_select">' + key + '</div>';
 
   document.getElementById('bo_faction_text').value = '';
   document.getElementById('bo_search_results').innerHTML = boSearchText;
@@ -2811,7 +2811,7 @@ function mouseClickSearchResult(key) {
 function updateLibrarySearch() {
   // Value to search in lower case
   const searchStr =
-    document.getElementById('bo_faction_text').value.toLowerCase();
+      document.getElementById('bo_faction_text').value.toLowerCase();
 
   // Selected BO is null if the search field is not empty
   if (searchStr !== '') {
@@ -2823,23 +2823,23 @@ function updateLibrarySearch() {
   // Library is empty
   if (Object.keys(library).length === 0) {
     boSearchText +=
-      '<div>No build order in library for <i>' + gameFullName + '</i>.</div>';
+        '<div>No build order in library for <i>' + gameFullName + '</i>.</div>';
     if (gameName in EXTERNAL_BO_WEBSITES) {
       boSearchText +=
-        '<div>Download one <b>from an external website</b> or <b>design your own</b>.</div>';
+          '<div>Download one <b>from an external website</b> or <b>design your own</b>.</div>';
     } else {
       boSearchText +=
-        '<div><b>Design your own</b> build order in the corresponding panel.</div>';
+          '<div><b>Design your own</b> build order in the corresponding panel.</div>';
     }
   }
   // No build order for the currently selected faction condition
   else if (libraryValidKeys.length === 0) {
     boSearchText += '<div>No build order in your library for faction <b>' +
-      document.getElementById('bo_faction_select_widget').value + '</b>';
+        document.getElementById('bo_faction_select_widget').value + '</b>';
     if (FACTION_FIELD_NAMES[gameName]['opponent']) {
       boSearchText += ' with opponent <b>' +
-        document.getElementById('bo_opponent_faction_select_widget').value +
-        '</b>';
+          document.getElementById('bo_opponent_faction_select_widget').value +
+          '</b>';
     }
     boSearchText += '.</div>';
   }
@@ -2848,26 +2848,26 @@ function updateLibrarySearch() {
     // Nothing added in the search field
     if (searchStr.length === 0) {
       const factionName =
-        document.getElementById('bo_faction_select_widget').value;
+          document.getElementById('bo_faction_select_widget').value;
       boSearchText += '<div>Select the player faction above (' +
-        factionsList[factionName][0] + ': <b>' + factionName + '</b>)';
+          factionsList[factionName][0] + ': <b>' + factionName + '</b>)';
 
       if (FACTION_FIELD_NAMES[gameName]['opponent']) {
         const opponentFactionName =
-          document.getElementById('bo_opponent_faction_select_widget').value;
+            document.getElementById('bo_opponent_faction_select_widget').value;
         boSearchText += ' and opponent faction (' +
-          factionsList[opponentFactionName][0] + ': <b>' +
-          opponentFactionName + '</b>)';
+            factionsList[opponentFactionName][0] + ': <b>' +
+            opponentFactionName + '</b>)';
       }
       boSearchText += '.</div>';
 
       boSearchText +=
-        '<div>Then, add <b>keywords</b> in the text field to search any build order from your library.</div>';
+          '<div>Then, add <b>keywords</b> in the text field to search any build order from your library.</div>';
       boSearchText +=
-        '<div>Alternatively, use <b>a single space</b> to select the first ' +
-        MAX_SEARCH_RESULTS + ' build orders.</div>';
+          '<div>Alternatively, use <b>a single space</b> to select the first ' +
+          MAX_SEARCH_RESULTS + ' build orders.</div>';
       boSearchText +=
-        '<div>Finally, click on the requested build order from the list (will appear here).</div>';
+          '<div>Finally, click on the requested build order from the list (will appear here).</div>';
     }
     // Look for pattern in search field
     else {
@@ -2883,7 +2883,7 @@ function updateLibrarySearch() {
         for (const key of libraryValidKeys) {
           const keyLowerCase = key.toLowerCase();
           const score = computeSameSizeLevenshteinThreshold(
-            LEVENSHTEIN_RATIO_THRESHOLD, searchStr, keyLowerCase);
+              LEVENSHTEIN_RATIO_THRESHOLD, searchStr, keyLowerCase);
           if (score >= 0) {  // Valid match
             librayKeyScores[key] = score;
             librarySortedKeys.push(key);
@@ -2891,14 +2891,14 @@ function updateLibrarySearch() {
         }
         // Sort the keys based on the metrics above
         librarySortedKeys.sort(
-          (a, b) => compareLibraryKeys(librayKeyScores, a, b));
+            (a, b) => compareLibraryKeys(librayKeyScores, a, b));
 
         // Only keep the first results
         librarySortedKeys = librarySortedKeys.slice(0, MAX_SEARCH_RESULTS);
 
         // Sort by faction requirement
         librarySortedKeys.sort(
-          (a, b) => compareLibraryFaction(keyCondition, a, b));
+            (a, b) => compareLibraryFaction(keyCondition, a, b));
       }
       // Take the first results, sorting only by faction requirement
       else {
@@ -2907,7 +2907,7 @@ function updateLibrarySearch() {
 
         // Sort by faction requirement
         librarySortedKeys.sort(
-          (a, b) => compareLibraryFaction(keyCondition, a, b));
+            (a, b) => compareLibraryFaction(keyCondition, a, b));
 
         // Only keep the first results
         librarySortedKeys = librarySortedKeys.slice(0, MAX_SEARCH_RESULTS);
@@ -2918,10 +2918,10 @@ function updateLibrarySearch() {
       let keyID = 0;
       for (const key of librarySortedKeys) {
         boSearchText += '<div id="search_key_line_' + keyID +
-          '" class="search_key_line" onmouseover="mouseOverSearchResult(' +
-          keyID +
-          ')" onmouseleave="clearSearchResultSelect()" onclick="mouseClickSearchResult(\'' +
-          key.replaceAll('\'', '\\\'') + '\')">' + key + '</div>';
+            '" class="search_key_line" onmouseover="mouseOverSearchResult(' +
+            keyID +
+            ')" onmouseleave="clearSearchResultSelect()" onclick="mouseClickSearchResult(\'' +
+            key.replaceAll('\'', '\\\'') + '\')">' + key + '</div>';
         keyID++;
       }
     }
@@ -2965,17 +2965,17 @@ class SinglePanelColumn {
    *                                     null for default.
    */
   constructor(
-    field, image = null, italic = false, bold = false, hideIfAbsent = false,
-    displayIfPositive = false, backgroundColor = null, textAlign = null) {
+      field, image = null, italic = false, bold = false, hideIfAbsent = false,
+      displayIfPositive = false, backgroundColor = null, textAlign = null) {
     // Check input types
     if (typeof field !== 'string' || (image && typeof image !== 'string') ||
-      (textAlign && typeof textAlign !== 'string')) {
+        (textAlign && typeof textAlign !== 'string')) {
       throw 'SinglePanelColumn expected strings for \'field\', \'image\' and \'textAlign\'.';
     }
 
     if (typeof italic !== 'boolean' || typeof bold !== 'boolean' ||
-      typeof hideIfAbsent !== 'boolean' ||
-      typeof displayIfPositive !== 'boolean') {
+        typeof hideIfAbsent !== 'boolean' ||
+        typeof displayIfPositive !== 'boolean') {
       throw 'SinglePanelColumn expected boolean for \'italic\',  \'bold\',  \'hideIfAbsent\' and  \'displayIfPositive\'.';
     }
 
@@ -3009,7 +3009,7 @@ class SinglePanelColumn {
  *                                    and 'after', null if no section.
  */
 function openSinglePanelPageFromDescription(
-  columnsDescription, sectionsHeader = null) {
+    columnsDescription, sectionsHeader = null) {
   // Check if valid BO data
   if (!checkValidBO()) {
     return;
@@ -3058,8 +3058,8 @@ function openSinglePanelPageFromDescription(
             }
           } else {
             console.log(
-              'Warning: Exepcted integer for \'' + field +
-              '\', but received \'' + fieldValue + '\'.');
+                'Warning: Exepcted integer for \'' + field +
+                '\', but received \'' + fieldValue + '\'.');
           }
         } else {
           displayColumns[index] = true;
@@ -3086,14 +3086,14 @@ function openSinglePanelPageFromDescription(
 
   // Title
   htmlContent +=
-    indentSpace(1) + '<title>RTS Overlay - ' + dataBO['name'] + '</title>\n';
+      indentSpace(1) + '<title>RTS Overlay - ' + dataBO['name'] + '</title>\n';
 
   // Style
   htmlContent += indentSpace(1) + '<style>\n';
 
   htmlContent += indentSpace(2) + 'body {\n';
   htmlContent +=
-    indentSpace(3) + 'font-family: Arial, Helvetica, sans-serif;\n';
+      indentSpace(3) + 'font-family: Arial, Helvetica, sans-serif;\n';
   htmlContent += indentSpace(3) + 'background-color: rgb(220, 220, 220);\n';
   htmlContent += indentSpace(2) + '}\n\n';
 
@@ -3167,7 +3167,7 @@ function openSinglePanelPageFromDescription(
   // Style from column description
   for (const [index, column] of updatedColumnsDescription.entries()) {
     if (column.italic || column.bold || column.backgroundColor ||
-      column.textAlign) {
+        column.textAlign) {
       htmlContent += indentSpace(2) + '.column-' + index.toString() + ' {\n';
 
       if (column.italic) {
@@ -3179,14 +3179,14 @@ function openSinglePanelPageFromDescription(
       if (column.backgroundColor) {
         color = column.backgroundColor;
         console.assert(
-          color.length == 3, 'Background color length should be of size 3.');
+            color.length == 3, 'Background color length should be of size 3.');
         htmlContent += indentSpace(3) + 'background-color: rgb(' +
-          color[0].toString() + ', ' + color[1].toString() + ', ' +
-          color[2].toString() + ');\n';
+            color[0].toString() + ', ' + color[1].toString() + ', ' +
+            color[2].toString() + ');\n';
       }
       if (column.textAlign) {
         htmlContent +=
-          indentSpace(3) + 'text-align: ' + column.textAlign + ';\n';
+            indentSpace(3) + 'text-align: ' + column.textAlign + ';\n';
       }
       htmlContent += indentSpace(2) + '}\n\n';
     }
@@ -3205,7 +3205,7 @@ function openSinglePanelPageFromDescription(
   for (const column of updatedColumnsDescription) {
     if (column.image) {
       htmlContent +=
-        indentSpace(3) + '<td>' + getBOImageHTML(column.image) + '</td>\n';
+          indentSpace(3) + '<td>' + getBOImageHTML(column.image) + '</td>\n';
     } else {
       indentSpace(3) + '<td></td>\n';
     }
@@ -3223,8 +3223,8 @@ function openSinglePanelPageFromDescription(
     if (sectionsHeader) {
       // Key to check for section header
       console.assert(
-        sectionsHeader.key in currentStep,
-        'Current step is missing \'' + sectionsHeader.key + '\'.');
+          sectionsHeader.key in currentStep,
+          'Current step is missing \'' + sectionsHeader.key + '\'.');
       const keyValue = currentStep[sectionsHeader.key];
 
       // Activate if first line or seen in the previous line
@@ -3232,7 +3232,7 @@ function openSinglePanelPageFromDescription(
         if (sectionsHeader.after && (keyValue in sectionsHeader.after)) {
           htmlContent += indentSpace(2) + '<tr class="border_top">\n';
           htmlContent += indentSpace(3) + '<td class="full_line" colspan=8>' +
-            sectionsHeader.after[keyValue] + '</td>\n';
+              sectionsHeader.after[keyValue] + '</td>\n';
           htmlContent += indentSpace(2) + '</tr>\n';
         }
         previousHeaderFlag = false;
@@ -3242,7 +3242,7 @@ function openSinglePanelPageFromDescription(
         if (sectionsHeader.before && (keyValue in sectionsHeader.before)) {
           htmlContent += indentSpace(2) + '<tr class="border_top">\n';
           htmlContent += indentSpace(3) + '<td class="full_line" colspan=8>' +
-            sectionsHeader.before[keyValue] + '</td>\n';
+              sectionsHeader.before[keyValue] + '</td>\n';
           htmlContent += indentSpace(2) + '</tr>\n';
         }
         previousHeaderFlag = true;
@@ -3283,14 +3283,14 @@ function openSinglePanelPageFromDescription(
               }
             } else {
               console.log(
-                'Warning: Exepcted integer for \'' + field +
-                '\', but received \'' + fieldValue + '\'.');
+                  'Warning: Exepcted integer for \'' + field +
+                  '\', but received \'' + fieldValue + '\'.');
             }
           }
 
           // Display field value
           htmlContent += indentSpace(3) + '<td class="column-' +
-            index.toString() + '">' + fieldValue + '</td>\n';
+              index.toString() + '">' + fieldValue + '</td>\n';
         }
       }
       // Only add notes for the next lines (i.e. no column content).
@@ -3298,14 +3298,14 @@ function openSinglePanelPageFromDescription(
         htmlContent += indentSpace(2) + '<tr>\n';
         for (let index = 0; index < updatedColumnsDescription.length; index++) {
           htmlContent += indentSpace(3) + '<td class="column-' +
-            index.toString() + '"></td>\n';
+              index.toString() + '"></td>\n';
         }
       }
 
       // Add the current note line
       htmlContent += indentSpace(3) + '<td class="note">\n' + indentSpace(4) +
-        '<div>' + noteToTextImages(note) + '</div>\n' + indentSpace(3) +
-        '</td>\n';
+          '<div>' + noteToTextImages(note) + '</div>\n' + indentSpace(3) +
+          '</td>\n';
       htmlContent += indentSpace(2) + '</tr>\n';
     }
   }
@@ -3314,12 +3314,12 @@ function openSinglePanelPageFromDescription(
 
   // Copy HTML for export
   const htmlContentCopy =
-    JSON.parse(JSON.stringify(htmlContent)) + '</body>\n\n</html>';
+      JSON.parse(JSON.stringify(htmlContent)) + '</body>\n\n</html>';
 
   // Name for file export
   const exportName = (Object.keys(dataBO).includes('name')) ?
-    dataBO.name.replaceAll(/\s+/g, '_') :
-    'rts_overlay';
+      dataBO.name.replaceAll(/\s+/g, '_') :
+      'rts_overlay';
 
   // Buttons to export HTML and build order
   htmlContent += '\n<button id="export_html">Export HTML</button>\n';
@@ -3328,35 +3328,35 @@ function openSinglePanelPageFromDescription(
   htmlContent += indentSpace(1) + '<script>\n';
 
   htmlContent += indentSpace(2) +
-    'const dataHTML = ' + JSON.stringify(htmlContentCopy) + ';\n\n';
+      'const dataHTML = ' + JSON.stringify(htmlContentCopy) + ';\n\n';
   htmlContent +=
-    indentSpace(2) + 'const dataBO = ' + JSON.stringify(dataBO) + ';\n\n';
+      indentSpace(2) + 'const dataBO = ' + JSON.stringify(dataBO) + ';\n\n';
 
   // Export HTML
   htmlContent += indentSpace(2) +
-    'document.getElementById(\'export_html\').addEventListener(\'click\', function() {\n';
+      'document.getElementById(\'export_html\').addEventListener(\'click\', function() {\n';
   htmlContent += indentSpace(3) +
-    'const fileHTML = new Blob([dataHTML], {type: \'text/plain\'});\n';
+      'const fileHTML = new Blob([dataHTML], {type: \'text/plain\'});\n';
   htmlContent +=
-    indentSpace(3) + 'const link = document.createElement(\'a\');\n';
+      indentSpace(3) + 'const link = document.createElement(\'a\');\n';
   htmlContent +=
-    indentSpace(3) + 'link.href = URL.createObjectURL(fileHTML);\n';
+      indentSpace(3) + 'link.href = URL.createObjectURL(fileHTML);\n';
   htmlContent +=
-    indentSpace(3) + 'link.download = \'' + exportName + '.html\';\n';
+      indentSpace(3) + 'link.download = \'' + exportName + '.html\';\n';
   htmlContent += indentSpace(3) + 'link.click();\n';
   htmlContent += indentSpace(3) + 'URL.revokeObjectURL(link.href);\n';
   htmlContent += indentSpace(2) + '});\n\n';
 
   // Export BO
   htmlContent += indentSpace(2) +
-    'document.getElementById(\'export_bo\').addEventListener(\'click\', function() {\n';
+      'document.getElementById(\'export_bo\').addEventListener(\'click\', function() {\n';
   htmlContent += indentSpace(3) +
-    'const fileBO = new Blob([JSON.stringify(dataBO, null, 4)], {type: \'text/plain\'});\n';
+      'const fileBO = new Blob([JSON.stringify(dataBO, null, 4)], {type: \'text/plain\'});\n';
   htmlContent +=
-    indentSpace(3) + 'const link = document.createElement(\'a\');\n';
+      indentSpace(3) + 'const link = document.createElement(\'a\');\n';
   htmlContent += indentSpace(3) + 'link.href = URL.createObjectURL(fileBO);\n';
   htmlContent +=
-    indentSpace(3) + 'link.download = \'' + exportName + '.json\';\n';
+      indentSpace(3) + 'link.download = \'' + exportName + '.json\';\n';
   htmlContent += indentSpace(3) + 'link.click();\n';
   htmlContent += indentSpace(3) + 'URL.revokeObjectURL(link.href);\n';
   htmlContent += indentSpace(2) + '});\n\n';
@@ -3389,7 +3389,7 @@ function displayOverlay() {
 
   // Build order initialized for step 0
   const bodyContent = '<div id="bo_panel">' +
-    getBOPanelContent(true, validBO ? 0 : -1) + '</div>';
+      getBOPanelContent(true, validBO ? 0 : -1) + '</div>';
 
   // HTML content
   let htmlContent = '<!DOCTYPE html><html lang="en">';
@@ -3401,14 +3401,14 @@ function displayOverlay() {
   htmlContent += '\nconst SLEEP_TIME = ' + SLEEP_TIME + ';';
   htmlContent += '\nconst INTERVAL_CALL_TIME = ' + INTERVAL_CALL_TIME + ';';
   htmlContent +=
-    '\nconst SIZE_UPDATE_THRESHOLD = ' + SIZE_UPDATE_THRESHOLD + ';';
+      '\nconst SIZE_UPDATE_THRESHOLD = ' + SIZE_UPDATE_THRESHOLD + ';';
   htmlContent += '\nconst OVERLAY_KEYBOARD_SHORTCUTS = ' +
-    JSON.stringify(OVERLAY_KEYBOARD_SHORTCUTS) + ';';
+      JSON.stringify(OVERLAY_KEYBOARD_SHORTCUTS) + ';';
   htmlContent += '\nconst ERROR_IMAGE = "' + ERROR_IMAGE + '";';
 
   htmlContent += '\nconst gameName = \'' + gameName + '\';';
   htmlContent +=
-    '\nconst dataBO = ' + (validBO ? JSON.stringify(dataBO) : 'null') + ';';
+      '\nconst dataBO = ' + (validBO ? JSON.stringify(dataBO) : 'null') + ';';
   htmlContent += '\nconst stepCount = ' + (validBO ? stepCount : -1) + ';';
   htmlContent += '\nlet stepID = ' + (validBO ? 0 : -1) + ';';
   htmlContent += '\nconst imagesGame = ' + JSON.stringify(imagesGame) + ';';
@@ -3417,19 +3417,19 @@ function displayOverlay() {
 
   const fontsizeSlider = document.getElementById('bo_fontsize');
   htmlContent += '\nconst bo_panel_font_size = \'' +
-    fontsizeSlider.value.toString(1) + 'em\';';
+      fontsizeSlider.value.toString(1) + 'em\';';
 
   // Adapt timer variables for overlay
   let timerOverlay = Object.assign({}, buildOrderTimer);  // copy the object
   timerOverlay['step_starting_flag'] =
-    TIMER_STEP_STARTING_FLAG.includes(gameName);
+      TIMER_STEP_STARTING_FLAG.includes(gameName);
   timerOverlay['absolute_time_init'] = getCurrentTime();
   timerOverlay['steps_ids'] = [0];
   if (gameName in TIMER_SPEED_FACTOR) {
     timerOverlay['timer_speed_factor'] = TIMER_SPEED_FACTOR[gameName];
   }
   htmlContent +=
-    '\nlet buildOrderTimer = ' + JSON.stringify(timerOverlay) + ';';
+      '\nlet buildOrderTimer = ' + JSON.stringify(timerOverlay) + ';';
 
   htmlContent += '\ninitOverlayWindow();';
 
@@ -3487,9 +3487,9 @@ function displayOverlay() {
   htmlContent += '\n</script>';
 
   htmlContent += '\n<head><link rel="stylesheet" href="layout.css">' +
-    headContent + '</head>';
+      headContent + '</head>';
   htmlContent +=
-    '\n<body id=\"body_overlay\">' + bodyContent + '</body></html>';
+      '\n<body id=\"body_overlay\">' + bodyContent + '</body></html>';
 
   // Update overlay HTML content
   overlayWindow.document.write(htmlContent);
@@ -3580,7 +3580,7 @@ function contentArrayToDiv(content) {
  * @returns Requested instructions.
  */
 function getArrayInstructions(
-  evaluateTimeFlag, selectFactionLines = null, externalBOLines = null) {
+    evaluateTimeFlag, selectFactionLines = null, externalBOLines = null) {
   let result = [
     'Replace the text in the panel below by any build order in correct JSON format, then click on \'Open full page\' or \'Display overlay\'',
     '(appearing on the left side of the screen when the build order is valid). You will need an Always On Top application',
@@ -3597,7 +3597,7 @@ function getArrayInstructions(
   const buttonsLines = [
     '',
     'You can' + (externalBOLines ? ' also' : '') +
-    ' manually write your build order as JSON format, using the following buttons',
+        ' manually write your build order as JSON format, using the following buttons',
     'from the <b>Design your own</b> section (some buttons only appear when the build order is valid):',
     '&nbsp &nbsp - \'Reset build order\' : Reset the build order to a minimal template (adapt the initial fields).',
     '&nbsp &nbsp - \'Add step\' : Add a step to the build order.',
@@ -3888,18 +3888,18 @@ function getResourceLineAoE2(currentStep) {
   const resources = currentStep.resources;
 
   htmlString +=
-    getBOImageValue(resourceFolder + 'Aoe2de_wood.png', resources, 'wood');
+      getBOImageValue(resourceFolder + 'Aoe2de_wood.png', resources, 'wood');
   htmlString +=
-    getBOImageValue(resourceFolder + 'Aoe2de_food.png', resources, 'food');
+      getBOImageValue(resourceFolder + 'Aoe2de_food.png', resources, 'food');
   htmlString +=
-    getBOImageValue(resourceFolder + 'Aoe2de_gold.png', resources, 'gold');
+      getBOImageValue(resourceFolder + 'Aoe2de_gold.png', resources, 'gold');
   htmlString +=
-    getBOImageValue(resourceFolder + 'Aoe2de_stone.png', resources, 'stone');
+      getBOImageValue(resourceFolder + 'Aoe2de_stone.png', resources, 'stone');
   htmlString += getBOImageValue(
-    resourceFolder + 'Aoe2de_hammer.png', resources, 'builder', true);
+      resourceFolder + 'Aoe2de_hammer.png', resources, 'builder', true);
   htmlString += getBOImageValue(
-    resourceFolder + 'MaleVillDE_alpha.png', currentStep, 'villager_count',
-    true);
+      resourceFolder + 'MaleVillDE_alpha.png', currentStep, 'villager_count',
+      true);
 
   // Age image
   const ageImage = {
@@ -3911,7 +3911,7 @@ function getResourceLineAoE2(currentStep) {
 
   if (currentStep.age in ageImage) {
     htmlString +=
-      getBOImageHTML(gamePicturesFolder + 'age/' + ageImage[currentStep.age]);
+        getBOImageHTML(gamePicturesFolder + 'age/' + ageImage[currentStep.age]);
   }
 
   return htmlString;
@@ -3975,15 +3975,15 @@ function getBOStepAoE2(builOrderData) {
       'villager_count': ('villager_count' in data) ? data['villager_count'] : 0,
       'age': ('age' in data) ? data['age'] : 1,
       'resources': ('resources' in data) ?
-        data['resources'] :
-        { 'wood': 0, 'food': 0, 'gold': 0, 'stone': 0 },
+          data['resources'] :
+          {'wood': 0, 'food': 0, 'gold': 0, 'stone': 0},
       'notes': ['Note 1', 'Note 2']
     };
   } else {
     return {
       'villager_count': 0,
       'age': 1,
-      'resources': { 'wood': 0, 'food': 0, 'gold': 0, 'stone': 0 },
+      'resources': {'wood': 0, 'food': 0, 'gold': 0, 'stone': 0},
       'notes': ['Note 1', 'Note 2']
     };
   }
@@ -4081,7 +4081,7 @@ function getLoomTimeAoE2(civilizationFlags, currentAge) {
  * @returns Requested research time [sec].
  */
 function getWheelbarrowHandcartTimeAoE2(
-  civilizationFlags, currentAge, wheelbarrowFlag) {
+    civilizationFlags, currentAge, wheelbarrowFlag) {
   console.assert(1 <= currentAge && currentAge <= 4, 'Age expected in [1;4].');
   const genericTime = wheelbarrowFlag ? 75.0 : 55.0;
   if (civilizationFlags['Persians']) {
@@ -4107,7 +4107,7 @@ function getWheelbarrowHandcartTimeAoE2(
  * @returns Requested research time [sec].
  */
 function getTownWatchPatrolTimeAoE2(
-  civilizationFlags, currentAge, townWatchFlag) {
+    civilizationFlags, currentAge, townWatchFlag) {
   console.assert(1 <= currentAge && currentAge <= 4, 'Age expected in [1;4].');
   const genericTime = townWatchFlag ? 25.0 : 40.0;
   if (civilizationFlags['Persians']) {
@@ -4131,7 +4131,7 @@ function getTownWatchPatrolTimeAoE2(
  * @returns Requested research time [sec].
  */
 function getTownCenterResearchTimeAoE2(
-  technologyName, civilizationFlags, currentAge) {
+    technologyName, civilizationFlags, currentAge) {
   if (technologyName === 'loom') {
     return getLoomTimeAoE2(civilizationFlags, currentAge);
   } else if (technologyName === 'wheelbarrow') {
@@ -4144,7 +4144,7 @@ function getTownCenterResearchTimeAoE2(
     return getTownWatchPatrolTimeAoE2(civilizationFlags, currentAge, false);
   } else {
     console.log(
-      'Warning: unknown TC technology name \'' + technologyName + '\'.');
+        'Warning: unknown TC technology name \'' + technologyName + '\'.');
     return 0.0;
   }
 }
@@ -4180,20 +4180,20 @@ function evaluateBOTimingAoE2(timeOffset) {
 
   // TC technologies to research
   TCTechnologies = {
-    'loom': { 'researched': false, 'image': 'town_center/LoomDE.png' },
+    'loom': {'researched': false, 'image': 'town_center/LoomDE.png'},
     'wheelbarrow':
-      { 'researched': false, 'image': 'town_center/WheelbarrowDE.png' },
-    'handcart': { 'researched': false, 'image': 'town_center/HandcartDE.png' },
-    'town_watch': { 'researched': false, 'image': 'town_center/TownWatchDE.png' },
+        {'researched': false, 'image': 'town_center/WheelbarrowDE.png'},
+    'handcart': {'researched': false, 'image': 'town_center/HandcartDE.png'},
+    'town_watch': {'researched': false, 'image': 'town_center/TownWatchDE.png'},
     'town_patrol':
-      { 'researched': false, 'image': 'town_center/TownPatrolDE.png' }
+        {'researched': false, 'image': 'town_center/TownPatrolDE.png'}
   };
 
   let lastTimeSec = timeOffset;  // time of the last step
 
   if (!('build_order' in dataBO)) {
     console.log(
-      'Warning: the "build_order" field is missing from data when evaluating the timing.');
+        'Warning: the "build_order" field is missing from data when evaluating the timing.');
     return;
   }
 
@@ -4211,8 +4211,8 @@ function evaluateBOTimingAoE2(timeOffset) {
     if (villagerCount < 0) {
       const resources = currentStep['resources'];
       villagerCount = Math.max(0, resources['wood']) +
-        Math.max(0, resources['food']) + Math.max(0, resources['gold']) +
-        Math.max(0, resources['stone']);
+          Math.max(0, resources['food']) + Math.max(0, resources['gold']) +
+          Math.max(0, resources['stone']);
       if ('builder' in resources) {
         villagerCount += Math.max(0, resources['builder']);
       }
@@ -4223,12 +4223,12 @@ function evaluateBOTimingAoE2(timeOffset) {
     lastVillagerCount = villagerCount;
 
     stepTotalTime += updateVillagerCount *
-      getVillagerTimeAoE2(civilizationFlags, currentAge);
+        getVillagerTimeAoE2(civilizationFlags, currentAge);
 
     // Next age
     const nextAge = (1 <= currentStep['age'] && currentStep['age'] <= 4) ?
-      currentStep['age'] :
-      currentAge;
+        currentStep['age'] :
+        currentAge;
     if (nextAge === currentAge + 1)  // researching next age up
     {
       stepTotalTime += getResearchAgeUpTimeAoE2(civilizationFlags, currentAge);
@@ -4244,11 +4244,11 @@ function evaluateBOTimingAoE2(timeOffset) {
     // Check for TC technologies in notes
     for (const note of currentStep['notes']) {
       for (const [technologyName, technologyData] of Object.entries(
-        TCTechnologies)) {
+               TCTechnologies)) {
         if ((!technologyData['researched']) &&
-          (note.includes('@' + technologyData['image'] + '@'))) {
+            (note.includes('@' + technologyData['image'] + '@'))) {
           stepTotalTime += getTownCenterResearchTimeAoE2(
-            technologyName, civilizationFlags, currentAge);
+              technologyName, civilizationFlags, currentAge);
           technologyData['researched'] = true;
         }
       }
@@ -4265,7 +4265,7 @@ function evaluateBOTimingAoE2(timeOffset) {
     // Special case for last step (add 1 sec to avoid displaying both at the
     // same time)
     if ((currentStepID === stepCount - 1) && (stepCount >= 2) &&
-      (currentStep['time'] === buildOrderData[currentStepID - 1]['time'])) {
+        (currentStep['time'] === buildOrderData[currentStepID - 1]['time'])) {
       currentStep['time'] = buildOrderTimeToStr(Math.round(lastTimeSec + 1.0));
     }
   }
@@ -4279,51 +4279,51 @@ function evaluateBOTimingAoE2(timeOffset) {
 function getImagesAoE2() {
   // This is obtained using the 'python/utilities/list_images.py' script.
   const
-    imagesDict =
-    {
-      'age':
-        'AgeUnknown.png#CastleAgeIconDE.png#CastleAgeIconDE_alpha.png#DarkAgeIconDE.png#DarkAgeIconDE_alpha.png#FeudalAgeIconDE.png#FeudalAgeIconDE_alpha.png#ImperialAgeIconDE.png#ImperialAgeIconDE_alpha.png',
-      'animal':
-        'AoE2DE_ingame_goose_icon.png#AoE2DE_ingame_ibex_icon.png#AoE2_DE_box_turtles_icon.png#AoE2_DE_dolphin_icon.png#AoE2_DE_dorado_icon.png#AoE2_DE_marlin_icon.png#AoE2_DE_perch_icon.png#AoE2_DE_salmon_icon.png#AoE2_DE_shore_fish_icon.png#AoE2_DE_snapper_icon.png#AoE2_DE_tuna_icon.png#Boar_aoe2DE.png#CowDE.png#Deer_aoe2DE.png#Elephant_aoe2DE.png#Goat_aoe2DE.png#Llama_aoe2DE.png#Ostrich_icon_aoe2de.png#Pig_aoe2DE.png#Rhinoceros_aoe2DE.png#Sheep_aoe2DE.png#Turkey_aoe2DE.png#Yak_aoe2DE.png#Zebra_aoe2DE.png',
-      'archery_range':
-        'Aoe2de_DOI_elephant_archer_icon.png#ArbalestDE.png#Arbalester_aoe2DE.png#Archery_range_aoe2DE.png#Archer_aoe2DE.png#Cavalryarcher_aoe2DE.png#Crossbowman_aoe2DE.png#ElephantArcherIcon-DE.png#Elite_skirmisher_aoe2DE.png#Hand_cannoneer_aoe2DE.png#Heavycavalryarcher_aoe2de.png#ImperialSkirmisherUpgDE.png#ParthianTacticsDE.png#Skirmisher_aoe2DE.png#ThumbRingDE.png#Heavy-cavalry-archer-resear.jpg',
-      'barracks':
-        'Aoe2-infantry-2-pikeman.png#ArsonDE.png#Barracks_aoe2DE.png#ChampionUpgDE.png#Champion_aoe2DE.png#Eaglescout_aoe2DE.png#EagleWarriorUpgDE.png#Eaglewarrior_aoe2DE.png#EliteEagleWarriorUpgDE.png#EliteEaglewarrior_aoe2DE.png#GambesonsDE.png#HalberdierDE.png#Halberdier_aoe2DE.png#LongSwordmanUpgDE.png#Longswordsman_aoe2DE.png#ManAtArmsUpgDE.png#Manatarms_aoe2DE.png#MilitiaDE.png#PikemanUpDE.png#Spearman_aoe2DE.png#SquiresDE.png#Suplliesicon.png#TwoHandedSwordsmanUpgDE.png#Twohanded_aoe2DE.png',
-      'blacksmith':
-        'Blacksmith_aoe2de.png#BlastFurnaceDE.png#BodkinArrowDE.png#BracerDE.png#ChainBardingDE.png#ChainMailArmorDE.png#FletchingDE.png#Forging_aoe2de.png#IronCastingDE.png#LeatherArcherArmorDE.png#PaddedArcherArmorDE.png#PlateBardingArmorDE.png#PlateMailArmorDE.png#RingArcherArmorDE.png#ScaleBardingArmorDE.png#ScaleMailArmorDE.png',
-      'castle':
-        'CastleAgeUnique.png#Castle_aoe2DE.png#ConscriptionDE.png#HoardingsDE.png#Petard_aoe2DE.png#SapperDE.png#SpiesDE.png#Trebuchet_aoe2DE.png#Unique-tech-imperial.jpg',
-      'civilization':
-        'CivIcon-Armenians.png#CivIcon-Aztecs.png#CivIcon-Bengalis.png#CivIcon-Berbers.png#CivIcon-Bohemians.png#CivIcon-Britons.png#CivIcon-Bulgarians.png#CivIcon-Burgundians.png#CivIcon-Burmese.png#CivIcon-Byzantines.png#CivIcon-Celts.png#CivIcon-Chinese.png#CivIcon-Cumans.png#CivIcon-Dravidians.png#CivIcon-Ethiopians.png#CivIcon-Franks.png#CivIcon-Georgians.png#CivIcon-Goths.png#CivIcon-Gurjaras.png#CivIcon-Hindustanis.png#CivIcon-Huns.png#CivIcon-Incas.png#CivIcon-Indians.png#CivIcon-Italians.png#CivIcon-Japanese.png#CivIcon-Khmer.png#CivIcon-Koreans.png#CivIcon-Lithuanians.png#CivIcon-Magyars.png#CivIcon-Malay.png#CivIcon-Malians.png#CivIcon-Mayans.png#CivIcon-Mongols.png#CivIcon-Persians.png#CivIcon-Poles.png#CivIcon-Portuguese.png#CivIcon-Romans.png#CivIcon-Saracens.png#CivIcon-Sicilians.png#CivIcon-Slavs.png#CivIcon-Spanish.png#CivIcon-Tatars.png#CivIcon-Teutons.png#CivIcon-Turks.png#CivIcon-Vietnamese.png#CivIcon-Vikings.png#question_mark.png#question_mark_black.png',
-      'defensive_structures':
-        'Bombard_tower_aoe2DE.png#Donjon_aoe2DE.png#FortifiedWallDE.png#Gate_aoe2de.png#Krepost_aoe2de.png#Outpost_aoe2de.png#Palisade_gate_aoe2DE.png#Palisade_wall_aoe2de.png#Stone_wall_aoe2de.png#Tower_aoe2de.png',
-      'dock':
-        'Cannon_galleon_aoe2DE.png#CareeningDE.png#Demoraft_aoe2DE.png#Demoship_aoe2DE.png#Dock_aoe2de.png#DryDockDE.png#Elite-cannon-galleon-resear.png#Elite_cannon_galleon_aoe2de.png#Fastfireship_aoe2DE.png#Fireship_aoe2DE.png#Fire_galley_aoe2DE.png#FishingShipDE.png#Fish_trap_aoe2DE.png#GalleonUpgDE.png#Galleon_aoe2DE.png#Galley_aoe2DE.png#GillnetsDE.png#Heavydemoship_aoe2de.png#ShipwrightDE.png#Trade_cog_aoe2DE.png#Transportship_aoe2DE.png#WarGalleyDE.png#War_galley_aoe2DE.png',
-      'lumber_camp':
-        'BowSawDE.png#DoubleBitAxe_aoe2DE.png#Lumber_camp_aoe2de.png#TwoManSawDE.png',
-      'market':
-        'BankingDE.png#CaravanDE.png#CoinageDE.png#GuildsDE.png#Market_aoe2DE.png#Tradecart_aoe2DE.png',
-      'mill':
-        'Aoe2-icon--folwark.png#CropRotationDE.png#FarmDE.png#HeavyPlowDE.png#HorseCollarDE.png#Mill_aoe2de.png',
-      'mining_camp':
-        'GoldMiningDE.png#GoldShaftMiningDE.png#Mining_camp_aoe2de.png#StoneMiningDE.png#StoneShaftMiningDE.png',
-      'monastery':
-        'AtonementDE.png#BlockPrintingDE.png#FaithDE.png#FervorDE.png#FortifiedChurch.png#HerbalDE.png#HeresyDE.png#IlluminationDE.png#MonasteryAoe2DE.png#Monk_aoe2DE.png#RedemptionDE.png#SanctityDE.png#TheocracyDE.png',
-      'other':
-        'Ao2de_caravanserai_icon.png#Feitoria_aoe2DE.png#House_aoe2DE.png#MuleCart.png#Wonder_aoe2DE.png',
-      'resource':
-        'Aoe2de_food.png#Aoe2de_gold.png#Aoe2de_hammer.png#Aoe2de_stone.png#Aoe2de_wood.png#BerryBushDE.png#MaleVillDE_alpha.png#tree.png#MaleVillDE.jpg',
-      'siege_workshop':
-        'AoE2DE_Armored_Elephant_icon.png#AoE2DE_Siege_Elephant_icon.png#Battering_ram_aoe2DE.png#Bombard_cannon_aoe2DE.png#CappedRamDE.png#Capped_ram_aoe2DE.png#HeavyScorpionDE.png#Heavyscorpion_aoe2DE.png#Mangonel_aoe2DE.png#OnagerDE.png#Onager_aoe2DE.png#Scorpion_aoe2DE.png#SiegeOnagerDE.png#Siegetower_aoe2DE.png#Siege_onager_aoe2DE.png#Siege_ram_aoe2DE.png#Siege_workshop_aoe2DE.png#Siege-ram-research.jpg',
-      'stable':
-        'Aoe2de_camel_scout.png#Aoe2_heavycamelriderDE.png#Battle_elephant_aoe2DE.png#BloodlinesDE.png#Camelrider_aoe2DE.png#Cavalier_aoe2DE.png#EliteBattleElephantUpg.png#Elitesteppelancericon.png#EliteSteppeLancerUpgDE.png#Elite_battle_elephant_aoe2DE.png#HeavyCamelUpgDE.png#HusbandryDE.png#Hussar_aoe2DE.png#Hussar_upgrade_aoe2de.png#Knight_aoe2DE.png#Lightcavalry_aoe2DE.png#Paladin_aoe2DE.png#Scoutcavalry_aoe2DE.png#Stable_aoe2DE.png#Steppelancericon.png#Winged-hussar_upgrade.png#Cavalier-research.jpg#Light-cavalry-research.jpg#Paladin-research.jpg',
-      'town_center':
-        'HandcartDE.png#LoomDE.png#Towncenter_aoe2DE.png#TownPatrolDE.png#TownWatchDE.png#WheelbarrowDE.png',
-      'unique_unit':
-        'Aoe2-icon--houfnice.png#Aoe2-icon--obuch.png#Aoe2-icon-coustillier.png#Aoe2-icon-flemish-militia.png#Aoe2-icon-hussite-wagon.png#Aoe2-icon-serjeant.png#Aoe2de_camel_scout.png#Aoe2de_Chakram.png#Aoe2de_Ghulam.png#Aoe2de_ratha_ranged.png#Aoe2de_shrivamsha_rider.png#Aoe2de_Thirisadai.png#Aoe2de_Urumi.png#Arambaiicon-DE.png#Ballistaelephanticon-DE.png#BerserkIcon-DE.png#BoyarIcon-DE.png#CamelArcherIcon-DE.png#CaravelIcon-DE.png#CataphractIcon-DE.png#Centurion-DE.png#ChukoNuIcon-DE.png#CompositeBowman.png#CondottieroIcon-DE.png#ConquistadorIcon-DE.png#Dromon-DE.png#Flaming_camel_icon.png#GbetoIcon-DE.png#GenitourIcon-DE.png#GenoeseCrossbowmanIcon-DE.png#HuskarlIcon-DE.png#ImperialCamelRiderIcon-DE.png#Imperialskirmishericon-DE.png#JaguarWarriorIcon-DE.png#JanissaryIcon-DE.png#KamayukIcon-DE.png#Karambitwarrioricon-DE.png#Keshikicon.png#Kipchakicon.png#Konnikicon.png#Legionary-DE.png#Leitisicon.png#LongboatIcon-DE.png#LongbowmanIcon-DE.png#MagyarHuszarIcon-DE.png#MamelukeIcon-DE.png#MangudaiIcon-DE.png#MissionaryIcon-DE.png#OrganGunIcon-DE.png#PlumedArcherIcon-DE.png#Rattanarchericon-DE.png#SamuraiIcon-DE.png#Shotelwarrioricon-DE.png#SlingerIcon-DE.png#TarkanIcon-DE.png#TeutonicKnightIcon-DE.png#ThrowingAxemanIcon-DE.png#TurtleShipIcon-DE.png#WarElephantIcon-DE.png#WarWagonIcon-DE.png#WoadRaiderIcon-DE.png#Monaspa.jpg#WarriorPriest.jpg',
-      'university':
-        'ArchitectureDE.png#ArrowSlitsDE.png#BallisticsDE.png#BombardTower_aoe2DE.png#ChemistryDE.png#FortifiedWallDE.png#HeatedShotDE.png#Masonry_aoe2de.png#MurderHolesDE.png#SiegeEngineersDE.png#Tower_aoe2de.png#TreadmillCraneDE.png#University_AoE2_DE.png'
-    };
+      imagesDict =
+          {
+            'age':
+                'AgeUnknown.png#CastleAgeIconDE.png#CastleAgeIconDE_alpha.png#DarkAgeIconDE.png#DarkAgeIconDE_alpha.png#FeudalAgeIconDE.png#FeudalAgeIconDE_alpha.png#ImperialAgeIconDE.png#ImperialAgeIconDE_alpha.png',
+            'animal':
+                'AoE2DE_ingame_goose_icon.png#AoE2DE_ingame_ibex_icon.png#AoE2_DE_box_turtles_icon.png#AoE2_DE_dolphin_icon.png#AoE2_DE_dorado_icon.png#AoE2_DE_marlin_icon.png#AoE2_DE_perch_icon.png#AoE2_DE_salmon_icon.png#AoE2_DE_shore_fish_icon.png#AoE2_DE_snapper_icon.png#AoE2_DE_tuna_icon.png#Boar_aoe2DE.png#CowDE.png#Deer_aoe2DE.png#Elephant_aoe2DE.png#Goat_aoe2DE.png#Llama_aoe2DE.png#Ostrich_icon_aoe2de.png#Pig_aoe2DE.png#Rhinoceros_aoe2DE.png#Sheep_aoe2DE.png#Turkey_aoe2DE.png#Yak_aoe2DE.png#Zebra_aoe2DE.png',
+            'archery_range':
+                'Aoe2de_DOI_elephant_archer_icon.png#ArbalestDE.png#Arbalester_aoe2DE.png#Archery_range_aoe2DE.png#Archer_aoe2DE.png#Cavalryarcher_aoe2DE.png#Crossbowman_aoe2DE.png#ElephantArcherIcon-DE.png#Elite_skirmisher_aoe2DE.png#Hand_cannoneer_aoe2DE.png#Heavycavalryarcher_aoe2de.png#ImperialSkirmisherUpgDE.png#ParthianTacticsDE.png#Skirmisher_aoe2DE.png#ThumbRingDE.png#Heavy-cavalry-archer-resear.jpg',
+            'barracks':
+                'Aoe2-infantry-2-pikeman.png#ArsonDE.png#Barracks_aoe2DE.png#ChampionUpgDE.png#Champion_aoe2DE.png#Eaglescout_aoe2DE.png#EagleWarriorUpgDE.png#Eaglewarrior_aoe2DE.png#EliteEagleWarriorUpgDE.png#EliteEaglewarrior_aoe2DE.png#GambesonsDE.png#HalberdierDE.png#Halberdier_aoe2DE.png#LongSwordmanUpgDE.png#Longswordsman_aoe2DE.png#ManAtArmsUpgDE.png#Manatarms_aoe2DE.png#MilitiaDE.png#PikemanUpDE.png#Spearman_aoe2DE.png#SquiresDE.png#Suplliesicon.png#TwoHandedSwordsmanUpgDE.png#Twohanded_aoe2DE.png',
+            'blacksmith':
+                'Blacksmith_aoe2de.png#BlastFurnaceDE.png#BodkinArrowDE.png#BracerDE.png#ChainBardingDE.png#ChainMailArmorDE.png#FletchingDE.png#Forging_aoe2de.png#IronCastingDE.png#LeatherArcherArmorDE.png#PaddedArcherArmorDE.png#PlateBardingArmorDE.png#PlateMailArmorDE.png#RingArcherArmorDE.png#ScaleBardingArmorDE.png#ScaleMailArmorDE.png',
+            'castle':
+                'CastleAgeUnique.png#Castle_aoe2DE.png#ConscriptionDE.png#HoardingsDE.png#Petard_aoe2DE.png#SapperDE.png#SpiesDE.png#Trebuchet_aoe2DE.png#Unique-tech-imperial.jpg',
+            'civilization':
+                'CivIcon-Armenians.png#CivIcon-Aztecs.png#CivIcon-Bengalis.png#CivIcon-Berbers.png#CivIcon-Bohemians.png#CivIcon-Britons.png#CivIcon-Bulgarians.png#CivIcon-Burgundians.png#CivIcon-Burmese.png#CivIcon-Byzantines.png#CivIcon-Celts.png#CivIcon-Chinese.png#CivIcon-Cumans.png#CivIcon-Dravidians.png#CivIcon-Ethiopians.png#CivIcon-Franks.png#CivIcon-Georgians.png#CivIcon-Goths.png#CivIcon-Gurjaras.png#CivIcon-Hindustanis.png#CivIcon-Huns.png#CivIcon-Incas.png#CivIcon-Indians.png#CivIcon-Italians.png#CivIcon-Japanese.png#CivIcon-Khmer.png#CivIcon-Koreans.png#CivIcon-Lithuanians.png#CivIcon-Magyars.png#CivIcon-Malay.png#CivIcon-Malians.png#CivIcon-Mayans.png#CivIcon-Mongols.png#CivIcon-Persians.png#CivIcon-Poles.png#CivIcon-Portuguese.png#CivIcon-Romans.png#CivIcon-Saracens.png#CivIcon-Sicilians.png#CivIcon-Slavs.png#CivIcon-Spanish.png#CivIcon-Tatars.png#CivIcon-Teutons.png#CivIcon-Turks.png#CivIcon-Vietnamese.png#CivIcon-Vikings.png#question_mark.png#question_mark_black.png',
+            'defensive_structures':
+                'Bombard_tower_aoe2DE.png#Donjon_aoe2DE.png#FortifiedWallDE.png#Gate_aoe2de.png#Krepost_aoe2de.png#Outpost_aoe2de.png#Palisade_gate_aoe2DE.png#Palisade_wall_aoe2de.png#Stone_wall_aoe2de.png#Tower_aoe2de.png',
+            'dock':
+                'Cannon_galleon_aoe2DE.png#CareeningDE.png#Demoraft_aoe2DE.png#Demoship_aoe2DE.png#Dock_aoe2de.png#DryDockDE.png#Elite-cannon-galleon-resear.png#Elite_cannon_galleon_aoe2de.png#Fastfireship_aoe2DE.png#Fireship_aoe2DE.png#Fire_galley_aoe2DE.png#FishingShipDE.png#Fish_trap_aoe2DE.png#GalleonUpgDE.png#Galleon_aoe2DE.png#Galley_aoe2DE.png#GillnetsDE.png#Heavydemoship_aoe2de.png#ShipwrightDE.png#Trade_cog_aoe2DE.png#Transportship_aoe2DE.png#WarGalleyDE.png#War_galley_aoe2DE.png',
+            'lumber_camp':
+                'BowSawDE.png#DoubleBitAxe_aoe2DE.png#Lumber_camp_aoe2de.png#TwoManSawDE.png',
+            'market':
+                'BankingDE.png#CaravanDE.png#CoinageDE.png#GuildsDE.png#Market_aoe2DE.png#Tradecart_aoe2DE.png',
+            'mill':
+                'Aoe2-icon--folwark.png#CropRotationDE.png#FarmDE.png#HeavyPlowDE.png#HorseCollarDE.png#Mill_aoe2de.png',
+            'mining_camp':
+                'GoldMiningDE.png#GoldShaftMiningDE.png#Mining_camp_aoe2de.png#StoneMiningDE.png#StoneShaftMiningDE.png',
+            'monastery':
+                'AtonementDE.png#BlockPrintingDE.png#FaithDE.png#FervorDE.png#FortifiedChurch.png#HerbalDE.png#HeresyDE.png#IlluminationDE.png#MonasteryAoe2DE.png#Monk_aoe2DE.png#RedemptionDE.png#SanctityDE.png#TheocracyDE.png',
+            'other':
+                'Ao2de_caravanserai_icon.png#Feitoria_aoe2DE.png#House_aoe2DE.png#MuleCart.png#Wonder_aoe2DE.png',
+            'resource':
+                'Aoe2de_food.png#Aoe2de_gold.png#Aoe2de_hammer.png#Aoe2de_stone.png#Aoe2de_wood.png#BerryBushDE.png#MaleVillDE_alpha.png#tree.png#MaleVillDE.jpg',
+            'siege_workshop':
+                'AoE2DE_Armored_Elephant_icon.png#AoE2DE_Siege_Elephant_icon.png#Battering_ram_aoe2DE.png#Bombard_cannon_aoe2DE.png#CappedRamDE.png#Capped_ram_aoe2DE.png#HeavyScorpionDE.png#Heavyscorpion_aoe2DE.png#Mangonel_aoe2DE.png#OnagerDE.png#Onager_aoe2DE.png#Scorpion_aoe2DE.png#SiegeOnagerDE.png#Siegetower_aoe2DE.png#Siege_onager_aoe2DE.png#Siege_ram_aoe2DE.png#Siege_workshop_aoe2DE.png#Siege-ram-research.jpg',
+            'stable':
+                'Aoe2de_camel_scout.png#Aoe2_heavycamelriderDE.png#Battle_elephant_aoe2DE.png#BloodlinesDE.png#Camelrider_aoe2DE.png#Cavalier_aoe2DE.png#EliteBattleElephantUpg.png#Elitesteppelancericon.png#EliteSteppeLancerUpgDE.png#Elite_battle_elephant_aoe2DE.png#HeavyCamelUpgDE.png#HusbandryDE.png#Hussar_aoe2DE.png#Hussar_upgrade_aoe2de.png#Knight_aoe2DE.png#Lightcavalry_aoe2DE.png#Paladin_aoe2DE.png#Scoutcavalry_aoe2DE.png#Stable_aoe2DE.png#Steppelancericon.png#Winged-hussar_upgrade.png#Cavalier-research.jpg#Light-cavalry-research.jpg#Paladin-research.jpg',
+            'town_center':
+                'HandcartDE.png#LoomDE.png#Towncenter_aoe2DE.png#TownPatrolDE.png#TownWatchDE.png#WheelbarrowDE.png',
+            'unique_unit':
+                'Aoe2-icon--houfnice.png#Aoe2-icon--obuch.png#Aoe2-icon-coustillier.png#Aoe2-icon-flemish-militia.png#Aoe2-icon-hussite-wagon.png#Aoe2-icon-serjeant.png#Aoe2de_camel_scout.png#Aoe2de_Chakram.png#Aoe2de_Ghulam.png#Aoe2de_ratha_ranged.png#Aoe2de_shrivamsha_rider.png#Aoe2de_Thirisadai.png#Aoe2de_Urumi.png#Arambaiicon-DE.png#Ballistaelephanticon-DE.png#BerserkIcon-DE.png#BoyarIcon-DE.png#CamelArcherIcon-DE.png#CaravelIcon-DE.png#CataphractIcon-DE.png#Centurion-DE.png#ChukoNuIcon-DE.png#CompositeBowman.png#CondottieroIcon-DE.png#ConquistadorIcon-DE.png#Dromon-DE.png#Flaming_camel_icon.png#GbetoIcon-DE.png#GenitourIcon-DE.png#GenoeseCrossbowmanIcon-DE.png#HuskarlIcon-DE.png#ImperialCamelRiderIcon-DE.png#Imperialskirmishericon-DE.png#JaguarWarriorIcon-DE.png#JanissaryIcon-DE.png#KamayukIcon-DE.png#Karambitwarrioricon-DE.png#Keshikicon.png#Kipchakicon.png#Konnikicon.png#Legionary-DE.png#Leitisicon.png#LongboatIcon-DE.png#LongbowmanIcon-DE.png#MagyarHuszarIcon-DE.png#MamelukeIcon-DE.png#MangudaiIcon-DE.png#MissionaryIcon-DE.png#OrganGunIcon-DE.png#PlumedArcherIcon-DE.png#Rattanarchericon-DE.png#SamuraiIcon-DE.png#Shotelwarrioricon-DE.png#SlingerIcon-DE.png#TarkanIcon-DE.png#TeutonicKnightIcon-DE.png#ThrowingAxemanIcon-DE.png#TurtleShipIcon-DE.png#WarElephantIcon-DE.png#WarWagonIcon-DE.png#WoadRaiderIcon-DE.png#Monaspa.jpg#WarriorPriest.jpg',
+            'university':
+                'ArchitectureDE.png#ArrowSlitsDE.png#BallisticsDE.png#BombardTower_aoe2DE.png#ChemistryDE.png#FortifiedWallDE.png#HeatedShotDE.png#Masonry_aoe2de.png#MurderHolesDE.png#SiegeEngineersDE.png#Tower_aoe2de.png#TreadmillCraneDE.png#University_AoE2_DE.png'
+          };
 
   // Split each string (e.g. 'image_0#image_1#image_2') in a list of images.
   for (const [key, value] of Object.entries(imagesDict)) {
@@ -4415,7 +4415,7 @@ function getInstructionsAoE2() {
     'click on \'Copy to clipboard for RTS Overlay\', then paste the content in the text panel below.'
   ];
   return contentArrayToDiv(
-    getArrayInstructions(true, selectFactionLines, externalBOLines));
+      getArrayInstructions(true, selectFactionLines, externalBOLines));
 }
 
 /**
@@ -4469,7 +4469,7 @@ function openSinglePanelPageAoE2() {
       2: getBOImageHTML(game + 'age/FeudalAgeIconDE_alpha.png') + 'Feudal Age',
       3: getBOImageHTML(game + 'age/CastleAgeIconDE_alpha.png') + 'Castle Age',
       4: getBOImageHTML(game + 'age/ImperialAgeIconDE_alpha.png') +
-        'Imperial Age'
+          'Imperial Age'
     }
   };
 
@@ -4497,29 +4497,29 @@ function getResourceLineAoE4(currentStep) {
   const resources = currentStep.resources;
 
   htmlString +=
-    getBOImageValue(resourceFolder + 'resource_food.png', resources, 'food');
+      getBOImageValue(resourceFolder + 'resource_food.png', resources, 'food');
   htmlString +=
-    getBOImageValue(resourceFolder + 'resource_wood.png', resources, 'wood');
+      getBOImageValue(resourceFolder + 'resource_wood.png', resources, 'wood');
   htmlString +=
-    getBOImageValue(resourceFolder + 'resource_gold.png', resources, 'gold');
+      getBOImageValue(resourceFolder + 'resource_gold.png', resources, 'gold');
   htmlString += getBOImageValue(
-    resourceFolder + 'resource_stone.png', resources, 'stone');
+      resourceFolder + 'resource_stone.png', resources, 'stone');
   htmlString += getBOImageValue(
-    resourceFolder + 'repair.png', resources, 'builder', true);
+      resourceFolder + 'repair.png', resources, 'builder', true);
   htmlString += getBOImageValue(
-    gamePicturesFolder + 'unit_worker/villager.png', currentStep,
-    'villager_count', true);
+      gamePicturesFolder + 'unit_worker/villager.png', currentStep,
+      'villager_count', true);
   htmlString += getBOImageValue(
-    gamePicturesFolder + 'building_economy/house.png', currentStep,
-    'population_count', true);
+      gamePicturesFolder + 'building_economy/house.png', currentStep,
+      'population_count', true);
 
   // Age image
   const ageImage =
-    { 1: 'age_1.png', 2: 'age_2.png', 3: 'age_3.png', 4: 'age_4.png' };
+      {1: 'age_1.png', 2: 'age_2.png', 3: 'age_3.png', 4: 'age_4.png'};
 
   if (currentStep.age in ageImage) {
     htmlString +=
-      getBOImageHTML(gamePicturesFolder + 'age/' + ageImage[currentStep.age]);
+        getBOImageHTML(gamePicturesFolder + 'age/' + ageImage[currentStep.age]);
   }
 
   return htmlString;
@@ -4582,12 +4582,12 @@ function getBOStepAoE4(builOrderData) {
     const data = builOrderData.at(-1);  // Last step data
     return {
       'population_count':
-        ('population_count' in data) ? data['population_count'] : -1,
+          ('population_count' in data) ? data['population_count'] : -1,
       'villager_count': ('villager_count' in data) ? data['villager_count'] : 0,
       'age': ('age' in data) ? data['age'] : 1,
       'resources': ('resources' in data) ?
-        data['resources'] :
-        { 'food': 0, 'wood': 0, 'gold': 0, 'stone': 0 },
+          data['resources'] :
+          {'food': 0, 'wood': 0, 'gold': 0, 'stone': 0},
       'notes': ['Note 1', 'Note 2']
     };
   } else {
@@ -4595,7 +4595,7 @@ function getBOStepAoE4(builOrderData) {
       'population_count': -1,
       'villager_count': 0,
       'age': 1,
-      'resources': { 'food': 0, 'wood': 0, 'gold': 0, 'stone': 0 },
+      'resources': {'food': 0, 'wood': 0, 'gold': 0, 'stone': 0},
       'notes': ['Note 1', 'Note 2']
     };
   }
@@ -4629,7 +4629,7 @@ function getBOTemplateAoE4() {
 function updateTownCenterTimeAoE4(initialTime, civilizationFlags, currentAge) {
   if (civilizationFlags['French']) {
     return initialTime /
-      (1.0 + 0.05 * (currentAge + 1));  // 10%/15%/20%/25% faster
+        (1.0 + 0.05 * (currentAge + 1));  // 10%/15%/20%/25% faster
   } else {
     return initialTime;
   }
@@ -4648,7 +4648,7 @@ function getVillagerTimeAoE4(civilizationFlags, currentAge) {
     return 23.0;
   } else {  // generic
     console.assert(
-      1 <= currentAge && currentAge <= 4, 'Age expected in [1;4].');
+        1 <= currentAge && currentAge <= 4, 'Age expected in [1;4].');
     return updateTownCenterTimeAoE4(20.0, civilizationFlags, currentAge);
   }
 }
@@ -4664,7 +4664,7 @@ function getVillagerTimeAoE4(civilizationFlags, currentAge) {
  * @returns Requested research time [sec].
  */
 function getTownCenterUnitResearchTimeAoE4(
-  name, civilizationFlags, currentAge) {
+    name, civilizationFlags, currentAge) {
   console.assert(1 <= currentAge && currentAge <= 4, 'Age expected in [1;4].');
   if (name === 'textiles') {
     if (civilizationFlags['Delhi']) {
@@ -4730,7 +4730,7 @@ function evaluateBOTimingAoE4(timeOffset) {
 
   if (!('build_order' in dataBO)) {
     console.log(
-      'Warning: the \'build_order\' field is missing from data when evaluating the timing.')
+        'Warning: the \'build_order\' field is missing from data when evaluating the timing.')
     return;
   }
 
@@ -4748,8 +4748,8 @@ function evaluateBOTimingAoE4(timeOffset) {
     if (villagerCount < 0) {
       const resources = currentStep['resources'];
       villagerCount = Math.max(0, resources['wood']) +
-        Math.max(0, resources['food']) + Math.max(0, resources['gold']) +
-        Math.max(0, resources['stone']);
+          Math.max(0, resources['food']) + Math.max(0, resources['gold']) +
+          Math.max(0, resources['stone']);
       if ('builder' in resources) {
         villagerCount += Math.max(0, resources['builder']);
       }
@@ -4760,27 +4760,27 @@ function evaluateBOTimingAoE4(timeOffset) {
     lastVillagerCount = villagerCount;
 
     stepTotalTime += updateVillagerCount *
-      getVillagerTimeAoE4(civilizationFlags, currentAge);
+        getVillagerTimeAoE4(civilizationFlags, currentAge);
 
     // next age
     const nextAge = (1 <= currentStep['age'] && currentStep['age'] <= 4) ?
-      currentStep['age'] :
-      currentAge;
+        currentStep['age'] :
+        currentAge;
 
     // Jeanne becomes a soldier in Feudal
     if (civilizationFlags['Jeanne'] && !jeanneMilitaryFlag && (nextAge > 1)) {
       stepTotalTime += get_villager_time(
-        civilizationFlags, currentAge);  // one extra villager to create
+          civilizationFlags, currentAge);  // one extra villager to create
       jeanneMilitaryFlag = true;
     }
 
     // Check for TC technologies or special units in notes
     for (note of currentStep['notes']) {
       for (const [tcItemName, tcItemImage] of Object.entries(
-        TCUnitTechnologies)) {
+               TCUnitTechnologies)) {
         if (note.includes('@' + tcItemImage + '@')) {
           stepTotalTime += getTownCenterUnitResearchTimeAoE4(
-            tcItemName, civilizationFlags, currentAge);
+              tcItemName, civilizationFlags, currentAge);
         }
       }
     }
@@ -4796,7 +4796,7 @@ function evaluateBOTimingAoE4(timeOffset) {
     // Special case for last step
     // (add 1 sec to avoid displaying both at the same time).
     if ((currentStepID === stepCount - 1) && (stepCount >= 2) &&
-      (currentStep['time'] === buildOrderData[currentStepID - 1]['time'])) {
+        (currentStep['time'] === buildOrderData[currentStepID - 1]['time'])) {
       currentStep['time'] = buildOrderTimeToStr(Math.round(lastTimeSec + 1.0));
     }
   }
@@ -4810,150 +4810,150 @@ function evaluateBOTimingAoE4(timeOffset) {
 function getImagesAoE4() {
   // This is obtained using the 'python/utilities/list_images.py' script.
   const imagesDict =
-  {
-    'abilities': 'attack-move.png#repair.png',
-    'ability_chinese': 'collect_tax.png#supervise.png',
-    'ability_jeanne':
-      'ability-champion-companions-1.png#ability-consecrate-1.png#ability-divine-arrow-1.png#ability-divine-restoration-1.png#ability-field-commander-1.png#ability-gunpowder-monarch-1.png#ability-holy-wrath-1.png#ability-path-of-the-archer-1.png#ability-path-of-the-warrior-1.png#ability-rider-companions-1.png#ability-riders-ready-1.png#ability-strength-of-heaven-1.png#ability-to-arms-men-1.png#ability-valorous-inspiration-1.png',
-    'age':
-      'age_1.png#age_2.png#age_3.png#age_4.png#age_unknown.png#goldenagetier1.png#goldenagetier2.png#goldenagetier3.png#goldenagetier4.png#goldenagetier5.png#vizier_point.png',
-    'building_byzantines':
-      'aqueduct-1.png#cistern-1.png#mercenary-house-2.png#olive-grove-1.png',
-    'building_chinese': 'granary.png#pagoda.png#village.png',
-    'building_defensive':
-      'keep.png#outpost.png#palisade-gate.png#palisade-wall.png#stone-wall-gate.png#stone-wall-tower.png#stone-wall.png',
-    'building_economy':
-      'farm.png#house.png#lumber-camp.png#market.png#mill.png#mining-camp.png#town-center.png',
-    'building_japanese':
-      'buddhist-temple-3.png#castle-4.png#farmhouse-1.png#forge-1.png#shinto-shrine-3.png',
-    'building_malians':
-      'cattle-ranch-2.png#pit-mine-1.png#toll-outpost-1.png',
-    'building_military':
-      'archery-range.png#barracks.png#dock.png#siege-workshop.png#stable.png',
-    'building_mongols': 'ger.png#ovoo.png#pasture.png#prayer-tent.png',
-    'building_ottomans': 'military-school-1.png',
-    'building_religious': 'monastery.png#mosque.png',
-    'building_rus':
-      'fortified-palisade-gate.png#fortified-palisade-wall.png#hunting-cabin.png#wooden-fortress.png',
-    'building_technology': 'blacksmith.png#madrasa.png#university.png',
-    'civilization_flag':
-      'abb.png#ayy.png#byz.png#chi.png#CivIcon-AbbasidAoE4.png#CivIcon-AbbasidAoE4_spacing.png#CivIcon-AyyubidsAoE4.png#CivIcon-AyyubidsAoE4_spacing.png#CivIcon-ByzantinesAoE4.png#CivIcon-ByzantinesAoE4_spacing.png#CivIcon-ChineseAoE4.png#CivIcon-ChineseAoE4_spacing.png#CivIcon-DelhiAoE4.png#CivIcon-DelhiAoE4_spacing.png#CivIcon-EnglishAoE4.png#CivIcon-EnglishAoE4_spacing.png#CivIcon-FrenchAoE4.png#CivIcon-FrenchAoE4_spacing.png#CivIcon-HREAoE4.png#CivIcon-HREAoE4_spacing.png#CivIcon-JapaneseAoE4.png#CivIcon-JapaneseAoE4_spacing.png#CivIcon-JeanneDArcAoE4.png#CivIcon-JeanneDArcAoE4_spacing.png#CivIcon-MaliansAoE4.png#CivIcon-MaliansAoE4_spacing.png#CivIcon-MongolsAoE4.png#CivIcon-MongolsAoE4_spacing.png#CivIcon-OrderOfTheDragonAoE4.png#CivIcon-OrderOfTheDragonAoE4_spacing.png#CivIcon-OttomansAoE4.png#CivIcon-OttomansAoE4_spacing.png#CivIcon-RusAoE4.png#CivIcon-RusAoE4_spacing.png#CivIcon-ZhuXiLegacyAoE4.png#CivIcon-ZhuXiLegacyAoE4_spacing.png#del.png#dra.png#eng.png#fre.png#hre.png#jap.png#jda.png#mal.png#mon.png#ott.png#rus.png#zxl.png',
-    'landmark_abbasid':
-      'culture-wing.png#economic-wing.png#house-of-wisdom.png#military-wing.png#prayer-hall-of-uqba.png#trade-wing.png',
-    'landmark_byzantines':
-      'cathedral-of-divine-wisdom-4.png#cistern-of-the-first-hill-2.png#foreign-engineering-company-3.png#golden-horn-tower-2.png#grand-winery-1.png#imperial-hippodrome-1.png#palatine-school-3.png',
-    'landmark_chinese':
-      'astronomical-clocktower.png#barbican-of-the-sun.png#enclave-of-the-emperor.png#great-wall-gatehouse.png#imperial-academy.png#imperial-palace.png#spirit-way.png',
-    'landmark_delhi':
-      'compound-of-the-defender.png#dome-of-the-faith.png#great-palace-of-agra.png#hisar-academy.png#house-of-learning.png#palace-of-the-sultan.png#tower-of-victory.png',
-    'landmark_english':
-      'abbey-of-kings.png#berkshire-palace.png#cathedral-of-st-thomas.png#council-hall.png#kings-palace.png#the-white-tower.png#wynguard-palace.png',
-    'landmark_french':
-      'chamber-of-commerce.png#college-of-artillery.png#guild-hall.png#notre-dame.png#red-palace.png#royal-institute.png#school-of-cavalry.png',
-    'landmark_hre': 'aachen-chapel.png#burgrave-palace.png#elzbach-palace.png#great-palace-of-flensburg.png#meinwerk-palace.png#palace-of-swabia.png#regnitz-cathedral.png',
-    'landmark_japanese':
-      'castle-of-the-crow-4.png#floating-gate-2.png#koka-township-1.png#kura-storehouse-1.png#tanegashima-gunsmith-3.png#temple-of-equality-2.png#tokugawa-shrine-4.png',
-    'landmark_malians':
-      'farimba-garrison-2.png#fort-of-the-huntress-3.png#grand-fulani-corral-2.png#great-mosque-4.png#griot-bara-3.png#mansa-quarry-2.png#saharan-trade-network-1.png',
-    'landmark_mongols':
-      'deer-stones.png#khaganate-palace.png#kurultai.png#monument-of-the-great-khan.png#steppe-redoubt.png#the-silver-tree.png#the-white-stupa.png',
-    'landmark_ottomans':
-      'azure-mosque-4.png#istanbul-imperial-palace-2.png#istanbul-observatory-3.png#mehmed-imperial-armory-2.png#sea-gate-castle-3.png#sultanhani-trade-network-1.png#twin-minaret-medrese-1.png',
-    'landmark_rus':
-      'abbey-of-the-trinity.png#cathedral-of-the-tsar.png#high-armory.png#high-trade-house.png#kremlin.png#spasskaya-tower.png#the-golden-gate.png',
-    'landmark_zhuxi':
-      'jiangnan-tower-2.png#meditation-gardens-1.png#mount-lu-academy-1.png#shaolin-monastery-2.png#temple-of-the-sun-3.png#zhu-xis-library-3.png',
-    'rank':
-      'bronze_1.png#bronze_2.png#bronze_3.png#conqueror_1.png#conqueror_2.png#conqueror_3.png#diamond_1.png#diamond_2.png#diamond_3.png#gold_1.png#gold_2.png#gold_3.png#platinum_1.png#platinum_2.png#platinum_3.png#silver_1.png#silver_2.png#silver_3.png',
-    'resource':
-      'berrybush.png#boar.png#bounty.png#cattle.png#deer.png#fish.png#gaiatreeprototypetree.png#oliveoil.png#rally.png#relics.png#repair.png#resource_food.png#resource_gold.png#resource_stone.png#resource_wood.png#sacred_sites.png#sheep.png#wolf.png',
-    'technology_abbasid':
-      'agriculture.png#armored-caravans.png#boot-camp.png#camel-handling.png#camel-rider-barding-4.png#camel-rider-shields.png#camel-support.png#composite-bows.png#faith.png#fertile-crescent-2.png#fresh-foodstuffs.png#grand-bazaar.png#improved-processing.png#medical-centers.png#phalanx.png#preservation-of-knowledge.png#public-library.png#spice-roads.png#teak-masts.png',
-    'technology_ayyubids':
-      'culture-wing-advancement-1.png#culture-wing-logistics-1.png#economic-wing-growth-1.png#economic-wing-industry-1.png#infantry-support-4.png#military-wing-master-smiths-1.png#military-wing-reinforcement-1.png#phalanx-2.png#siege-carpentry-3.png#sultans-mamluks-3.png#trade-wing-advisors-1.png#trade-wing-bazaar-1.png',
-    'technology_byzantines':
-      'border-settlements-2.png#eastern-mercenary-contract-1.png#elite-mercenaries-4.png#expilatores-2.png#ferocious-speed-4.png#greek-fire-projectiles-4.png#heavy-dromon-3.png#liquid-explosives-3.png#numeri-4.png#silk-road-mercenary-contract-1.png#teardrop-shields-3.png#trapezites-2.png#veteran-mercenaries-3.png#western-mercenary-contract-1.png',
-    'technology_chinese':
-      'ancient-techniques.png#battle-hardened.png#extra-hammocks.png#extra-materials.png#handcannon-slits.png#imperial-examination.png#pyrotechnics.png#reload-drills.png#reusable-barrels.png#thunderclap-bombs-4.png',
-    'technology_defensive':
-      'arrow-slits.png#boiling-oil.png#cannon-emplacement.png#court-architects.png#fortify-outpost.png#springald-emplacement.png',
-    'technology_delhi':
-      'all-seeing-eye.png#armored-beasts.png#efficient-production.png#forced-march.png#hearty-rations.png#honed-blades.png#lookout-towers.png#mahouts.png#manuscript-trade-1.png#paiks.png#reinforced-foundations.png#sanctity.png#siege-elephant.png#slow-burning-defenses.png#swiftness.png#tranquil-venue.png#village-fortresses.png#zeal.png',
-    'technology_dragon':
-      'bodkin-bolts-4.png#dragon-fire-2.png#dragon-scale-leather-3.png#golden-cuirass-2.png#war-horses-4.png#zornhau-3.png',
-    'technology_economy':
-      'acid-distilization.png#crosscut-saw.png#cupellation.png#double-broadaxe.png#drift-nets.png#extended-lines.png#fertilization.png#forestry.png#horticulture.png#lumber-preservation.png#precision-cross-breeding.png#professional-scouts.png#specialized-pick.png#survival-techniques.png#textiles.png#wheelbarrow.png',
-    'technology_english':
-      'admiralty-2.png#armor-clad.png#arrow-volley.png#enclosures.png#network-of-citadels.png#setup-camp.png#shattering-projectiles.png',
-    'technology_french':
-      'cantled-saddles.png#chivalry.png#crossbow-stirrups.png#enlistment-incentives.png#gambesons.png#long-guns.png#merchant-guilds-4.png#royal-bloodlines.png',
-    'technology_hre':
-      'benediction.png#devoutness.png#fire-stations.png#heavy-maces.png#inspired-warriors.png#marching-drills.png#reinforced-defenses.png#riveted-chain-mail-2.png#slate-and-stone-construction.png#steel-barding-3.png#two-handed-weapon.png',
-    'technology_japanese':
-      'bunrei.png#copper-plating-3.png#daimyo-manor-1.png#daimyo-palace-2.png#do-maru-armor-4.png#explosives-4.png#five_ministries.png#fudasashi-3.png#gion_festival.png#heated-shot-4.png#hizukuri-2.png#kabura-ya-whistling-arrow-3.png#kobuse-gitae-3.png#nagae-yari-4.png#nehan.png#oda-tactics-4.png#odachi-3.png#shinto_rituals.png#shogunate-castle-3.png#swivel-cannon-4.png#takezaiku-2.png#tatara-1.png#towara-1.png#yaki-ire-4.png#zen.png',
-    'technology_jeanne':
-      'companion-equipment-3.png#ordinance-company-3.png',
-    'technology_malians':
-      'banco-repairs-2.png#canoe-tactics-2.png#farima-leadership-4.png#imported-armor-3.png#local-knowledge-4.png#poisoned-arrows-3.png#precision-training-4.png',
-    'technology_military':
-      'angled-surfaces.png#balanced-projectiles.png#biology.png#bloomery.png#chemistry.png#damascus-steel.png#decarbonization.png#elite-army-tactics.png#fitted-leatherwork.png#geometry.png#greased-axles.png#incendiary-arrows.png#insulated-helm.png#iron-undermesh.png#master-smiths.png#military-academy.png#platecutter-point.png#siege-engineering.png#siege-works.png#steeled-arrow.png#wedge-rivets.png',
-    'technology_mongols':
-      'additional-torches.png#monastic-shrines.png#piracy.png#raid-bounty.png#siha-bow-limbs.png#steppe-lancers.png#stone-bounty.png#stone-commerce.png#superior-mobility.png#whistling-arrows.png#yam-network.png',
-    'technology_naval':
-      'additional-sails.png#armored-hull.png#chaser-cannons.png#explosives.png#extra-ballista.png#incendiaries-3.png#naval-arrow-slits.png#navigator-lookout.png#shipwrights-4.png#springald-crews-3.png',
-    'technology_ottomans':
-      'advanced-academy-1.png#anatolian-hills-1.png#fast-training-1.png#field-work-1.png#great-bombard-emplacement.png#imperial-fleet-4.png#janissary-company-1.png#janissary-guns-4.png#mehter-drums-1.png#military-campus-1.png#siege-crews-1.png#trade-bags-1.png',
-    'technology_religious': 'herbal-medicine.png#piety.png#tithe-barns.png',
-    'technology_rus':
-      'adaptable-hulls-3.png#banded-arms.png#blessing-duration.png#boyars-fortitude.png#castle-turret.png#castle-watch.png#cedar-hulls.png#clinker-construction.png#double-time.png#fine-tuned-guns.png#improved-blessing.png#knight-sabers.png#mounted-training.png#saints-reach.png#saints-veneration-4.png#siege-crew-training.png#wandering-town.png#warrior_scout_2.png',
-    'technology_units':
-      'adjustable-crossbars.png#lightweight-beams-4.png#roller-shutter-triggers.png#spyglass-4.png',
-    'technology_zhuxi':
-      '10000-bolts-4.png#advanced-administration-4.png#cloud-of-terror-4.png#dynastic-protectors-4.png#imperial-red-seals-3.png#military-affairs-bureau-1.png#roar-of-the-dragon-4.png',
-    'unit_abbasid':
-      'camel-archer-2.png#camel-rider-3.png#ghulam-3.png#imam.png',
-    'unit_ayyubids':
-      'atabeg-1.png#bedouin-skirmisher-2.png#bedouin-swordsman-1.png#camel-lancer-3.png#dervish-3.png#desert-raider-2.png#manjaniq-3.png#tower-of-the-sultan-3.png',
-    'unit_byzantines':
-      'arbaletrier-3.png#camel-archer-2.png#camel-rider-3.png#cataphract-3.png#cheirosiphon-3.png#desert-raider-2.png#dromon-2.png#ghulam-3.png#grenadier-4.png#horse-archer-3.png#javelin-thrower-2.png#keshik-2.png#landsknecht-3.png#limitanei-1.png#longbowman-2.png#mangudai.png#musofadi-warrior-2.png#royal-knight-2.png#sipahi-2.png#streltsy.png#tower-elephant-3.png#tower-of-the-sultan-3.png#varangian-guard-3.png#war-elephant.png#zhuge-nu-2.png',
-    'unit_cavalry':
-      'horseman-1.png#knight-2.png#lancer-3.png#lancer-4.png#scout.png',
-    'unit_chinese':
-      'fire-lancer-3.png#grenadier-4.png#imperial-official.png#junk.png#nest-of-bees.png#palace-guard-3.png#zhuge-nu-2.png',
-    'unit_delhi':
-      'ghazi-raider-2.png#scholar.png#sultans-elite-tower-elephant-4.png#tower-elephant-3.png#war-elephant.png',
-    'unit_dragon':
-      'dragon-handcannoneer-4.png#gilded-archer-2.png#gilded-crossbowman-3.png#gilded-horseman-2.png#gilded-knight-3.png#gilded-landsknecht-3.png#gilded-man-at-arms-2.png#gilded-spearman-1.png',
-    'unit_english':
-      'king-2.png#longbowman-2.png#wynguard-army-1.png#wynguard-footmen-1.png#wynguard-raiders-1.png#wynguard-ranger-4.png',
-    'unit_events': 'land_monster.png#water_monster.png',
-    'unit_french':
-      'arbaletrier-3.png#cannon-4.png#galleass.png#royal-cannon-4.png#royal-culverin-4.png#royal-knight-2.png#royal-ribauldequin-4.png#war-cog.png',
-    'unit_hre': 'landsknecht-3.png#prelate.png',
-    'unit_infantry':
-      'archer-2.png#crossbowman-3.png#handcannoneer-4.png#man-at-arms-1.png#spearman-1.png',
-    'unit_japanese':
-      'atakebune-4.png#buddhist-monk-3.png#katana-bannerman-2.png#mounted-samurai-3.png#onna-bugeisha-2.png#onna-musha-3.png#ozutsu-4.png#samurai-1.png#shinobi-2.png#shinto-priest-3.png#uma-bannerman-2.png#yumi-ashigaru-2.png#yumi-bannerman-2.png',
-    'unit_jeanne':
-      'jeanne-darc-blast-cannon-4.png#jeanne-darc-hunter-2.png#jeanne-darc-knight-3.png#jeanne-darc-markswoman-4.png#jeanne-darc-mounted-archer-3.png#jeanne-darc-peasant-1.png#jeanne-darc-woman-at-arms-2.png#jeannes-champion-3.png#jeannes-rider-3.png',
-    'unit_malians':
-      'donso-1.png#hunting-canoe-2.png#javelin-thrower-2.png#musofadi-gunner-4.png#musofadi-warrior-2.png#sofa-2.png#war-canoe-2.png#warrior-scout-2.png',
-    'unit_mongols':
-      'huihui-pao-1.png#keshik-2.png#khan-1.png#khans-hunter.png#light-junk.png#mangudai.png#shaman.png#traction-trebuchet.png',
-    'unit_ottomans':
-      'grand-galley-4.png#great-bombard-4.png#janissary-3.png#mehter-2.png#scout-ship-2.png#sipahi-2.png',
-    'unit_religious': 'imam-3.png#monk-3.png',
-    'unit_rus':
-      'horse-archer-3.png#lodya-attack-ship.png#lodya-demolition-ship.png#lodya-fishing-boat.png#lodya-galley-3.png#lodya-trade-ship.png#lodya-transport-ship.png#militia-2.png#streltsy.png#warrior-monk.png',
-    'unit_ship':
-      'baghlah.png#baochuan.png#carrack.png#demolition-ship.png#dhow.png#explosive-dhow.png#explosive-junk.png#fishing-boat.png#galley.png#hulk.png#junk-3.png#light-junk-2.png#trade-ship.png#transport-ship.png#war-junk.png#xebec.png',
-    'unit_siege':
-      'battering-ram.png#bombard.png#culverin-4.png#mangonel-3.png#ribauldequin-4.png#siege-tower.png#springald.png#trebuchet.png',
-    'unit_worker':
-      'monk-3.png#trader.png#villager-abbasid.png#villager-china.png#villager-delhi.png#villager-japanese.png#villager-malians.png#villager-mongols.png#villager-ottomans.png#villager.png',
-    'unit_zhuxi':
-      'imperial-guard-1.png#shaolin-monk-3.png#yuan-raider-4.png'
-  };
+      {
+        'abilities': 'attack-move.png#repair.png',
+        'ability_chinese': 'collect_tax.png#supervise.png',
+        'ability_jeanne':
+            'ability-champion-companions-1.png#ability-consecrate-1.png#ability-divine-arrow-1.png#ability-divine-restoration-1.png#ability-field-commander-1.png#ability-gunpowder-monarch-1.png#ability-holy-wrath-1.png#ability-path-of-the-archer-1.png#ability-path-of-the-warrior-1.png#ability-rider-companions-1.png#ability-riders-ready-1.png#ability-strength-of-heaven-1.png#ability-to-arms-men-1.png#ability-valorous-inspiration-1.png',
+        'age':
+            'age_1.png#age_2.png#age_3.png#age_4.png#age_unknown.png#goldenagetier1.png#goldenagetier2.png#goldenagetier3.png#goldenagetier4.png#goldenagetier5.png#vizier_point.png',
+        'building_byzantines':
+            'aqueduct-1.png#cistern-1.png#mercenary-house-2.png#olive-grove-1.png',
+        'building_chinese': 'granary.png#pagoda.png#village.png',
+        'building_defensive':
+            'keep.png#outpost.png#palisade-gate.png#palisade-wall.png#stone-wall-gate.png#stone-wall-tower.png#stone-wall.png',
+        'building_economy':
+            'farm.png#house.png#lumber-camp.png#market.png#mill.png#mining-camp.png#town-center.png',
+        'building_japanese':
+            'buddhist-temple-3.png#castle-4.png#farmhouse-1.png#forge-1.png#shinto-shrine-3.png',
+        'building_malians':
+            'cattle-ranch-2.png#pit-mine-1.png#toll-outpost-1.png',
+        'building_military':
+            'archery-range.png#barracks.png#dock.png#siege-workshop.png#stable.png',
+        'building_mongols': 'ger.png#ovoo.png#pasture.png#prayer-tent.png',
+        'building_ottomans': 'military-school-1.png',
+        'building_religious': 'monastery.png#mosque.png',
+        'building_rus':
+            'fortified-palisade-gate.png#fortified-palisade-wall.png#hunting-cabin.png#wooden-fortress.png',
+        'building_technology': 'blacksmith.png#madrasa.png#university.png',
+        'civilization_flag':
+            'abb.png#ayy.png#byz.png#chi.png#CivIcon-AbbasidAoE4.png#CivIcon-AbbasidAoE4_spacing.png#CivIcon-AyyubidsAoE4.png#CivIcon-AyyubidsAoE4_spacing.png#CivIcon-ByzantinesAoE4.png#CivIcon-ByzantinesAoE4_spacing.png#CivIcon-ChineseAoE4.png#CivIcon-ChineseAoE4_spacing.png#CivIcon-DelhiAoE4.png#CivIcon-DelhiAoE4_spacing.png#CivIcon-EnglishAoE4.png#CivIcon-EnglishAoE4_spacing.png#CivIcon-FrenchAoE4.png#CivIcon-FrenchAoE4_spacing.png#CivIcon-HREAoE4.png#CivIcon-HREAoE4_spacing.png#CivIcon-JapaneseAoE4.png#CivIcon-JapaneseAoE4_spacing.png#CivIcon-JeanneDArcAoE4.png#CivIcon-JeanneDArcAoE4_spacing.png#CivIcon-MaliansAoE4.png#CivIcon-MaliansAoE4_spacing.png#CivIcon-MongolsAoE4.png#CivIcon-MongolsAoE4_spacing.png#CivIcon-OrderOfTheDragonAoE4.png#CivIcon-OrderOfTheDragonAoE4_spacing.png#CivIcon-OttomansAoE4.png#CivIcon-OttomansAoE4_spacing.png#CivIcon-RusAoE4.png#CivIcon-RusAoE4_spacing.png#CivIcon-ZhuXiLegacyAoE4.png#CivIcon-ZhuXiLegacyAoE4_spacing.png#del.png#dra.png#eng.png#fre.png#hre.png#jap.png#jda.png#mal.png#mon.png#ott.png#rus.png#zxl.png',
+        'landmark_abbasid':
+            'culture-wing.png#economic-wing.png#house-of-wisdom.png#military-wing.png#prayer-hall-of-uqba.png#trade-wing.png',
+        'landmark_byzantines':
+            'cathedral-of-divine-wisdom-4.png#cistern-of-the-first-hill-2.png#foreign-engineering-company-3.png#golden-horn-tower-2.png#grand-winery-1.png#imperial-hippodrome-1.png#palatine-school-3.png',
+        'landmark_chinese':
+            'astronomical-clocktower.png#barbican-of-the-sun.png#enclave-of-the-emperor.png#great-wall-gatehouse.png#imperial-academy.png#imperial-palace.png#spirit-way.png',
+        'landmark_delhi':
+            'compound-of-the-defender.png#dome-of-the-faith.png#great-palace-of-agra.png#hisar-academy.png#house-of-learning.png#palace-of-the-sultan.png#tower-of-victory.png',
+        'landmark_english':
+            'abbey-of-kings.png#berkshire-palace.png#cathedral-of-st-thomas.png#council-hall.png#kings-palace.png#the-white-tower.png#wynguard-palace.png',
+        'landmark_french':
+            'chamber-of-commerce.png#college-of-artillery.png#guild-hall.png#notre-dame.png#red-palace.png#royal-institute.png#school-of-cavalry.png',
+        'landmark_hre': 'aachen-chapel.png#burgrave-palace.png#elzbach-palace.png#great-palace-of-flensburg.png#meinwerk-palace.png#palace-of-swabia.png#regnitz-cathedral.png',
+        'landmark_japanese':
+            'castle-of-the-crow-4.png#floating-gate-2.png#koka-township-1.png#kura-storehouse-1.png#tanegashima-gunsmith-3.png#temple-of-equality-2.png#tokugawa-shrine-4.png',
+        'landmark_malians':
+            'farimba-garrison-2.png#fort-of-the-huntress-3.png#grand-fulani-corral-2.png#great-mosque-4.png#griot-bara-3.png#mansa-quarry-2.png#saharan-trade-network-1.png',
+        'landmark_mongols':
+            'deer-stones.png#khaganate-palace.png#kurultai.png#monument-of-the-great-khan.png#steppe-redoubt.png#the-silver-tree.png#the-white-stupa.png',
+        'landmark_ottomans':
+            'azure-mosque-4.png#istanbul-imperial-palace-2.png#istanbul-observatory-3.png#mehmed-imperial-armory-2.png#sea-gate-castle-3.png#sultanhani-trade-network-1.png#twin-minaret-medrese-1.png',
+        'landmark_rus':
+            'abbey-of-the-trinity.png#cathedral-of-the-tsar.png#high-armory.png#high-trade-house.png#kremlin.png#spasskaya-tower.png#the-golden-gate.png',
+        'landmark_zhuxi':
+            'jiangnan-tower-2.png#meditation-gardens-1.png#mount-lu-academy-1.png#shaolin-monastery-2.png#temple-of-the-sun-3.png#zhu-xis-library-3.png',
+        'rank':
+            'bronze_1.png#bronze_2.png#bronze_3.png#conqueror_1.png#conqueror_2.png#conqueror_3.png#diamond_1.png#diamond_2.png#diamond_3.png#gold_1.png#gold_2.png#gold_3.png#platinum_1.png#platinum_2.png#platinum_3.png#silver_1.png#silver_2.png#silver_3.png',
+        'resource':
+            'berrybush.png#boar.png#bounty.png#cattle.png#deer.png#fish.png#gaiatreeprototypetree.png#oliveoil.png#rally.png#relics.png#repair.png#resource_food.png#resource_gold.png#resource_stone.png#resource_wood.png#sacred_sites.png#sheep.png#wolf.png',
+        'technology_abbasid':
+            'agriculture.png#armored-caravans.png#boot-camp.png#camel-handling.png#camel-rider-barding-4.png#camel-rider-shields.png#camel-support.png#composite-bows.png#faith.png#fertile-crescent-2.png#fresh-foodstuffs.png#grand-bazaar.png#improved-processing.png#medical-centers.png#phalanx.png#preservation-of-knowledge.png#public-library.png#spice-roads.png#teak-masts.png',
+        'technology_ayyubids':
+            'culture-wing-advancement-1.png#culture-wing-logistics-1.png#economic-wing-growth-1.png#economic-wing-industry-1.png#infantry-support-4.png#military-wing-master-smiths-1.png#military-wing-reinforcement-1.png#phalanx-2.png#siege-carpentry-3.png#sultans-mamluks-3.png#trade-wing-advisors-1.png#trade-wing-bazaar-1.png',
+        'technology_byzantines':
+            'border-settlements-2.png#eastern-mercenary-contract-1.png#elite-mercenaries-4.png#expilatores-2.png#ferocious-speed-4.png#greek-fire-projectiles-4.png#heavy-dromon-3.png#liquid-explosives-3.png#numeri-4.png#silk-road-mercenary-contract-1.png#teardrop-shields-3.png#trapezites-2.png#veteran-mercenaries-3.png#western-mercenary-contract-1.png',
+        'technology_chinese':
+            'ancient-techniques.png#battle-hardened.png#extra-hammocks.png#extra-materials.png#handcannon-slits.png#imperial-examination.png#pyrotechnics.png#reload-drills.png#reusable-barrels.png#thunderclap-bombs-4.png',
+        'technology_defensive':
+            'arrow-slits.png#boiling-oil.png#cannon-emplacement.png#court-architects.png#fortify-outpost.png#springald-emplacement.png',
+        'technology_delhi':
+            'all-seeing-eye.png#armored-beasts.png#efficient-production.png#forced-march.png#hearty-rations.png#honed-blades.png#lookout-towers.png#mahouts.png#manuscript-trade-1.png#paiks.png#reinforced-foundations.png#sanctity.png#siege-elephant.png#slow-burning-defenses.png#swiftness.png#tranquil-venue.png#village-fortresses.png#zeal.png',
+        'technology_dragon':
+            'bodkin-bolts-4.png#dragon-fire-2.png#dragon-scale-leather-3.png#golden-cuirass-2.png#war-horses-4.png#zornhau-3.png',
+        'technology_economy':
+            'acid-distilization.png#crosscut-saw.png#cupellation.png#double-broadaxe.png#drift-nets.png#extended-lines.png#fertilization.png#forestry.png#horticulture.png#lumber-preservation.png#precision-cross-breeding.png#professional-scouts.png#specialized-pick.png#survival-techniques.png#textiles.png#wheelbarrow.png',
+        'technology_english':
+            'admiralty-2.png#armor-clad.png#arrow-volley.png#enclosures.png#network-of-citadels.png#setup-camp.png#shattering-projectiles.png',
+        'technology_french':
+            'cantled-saddles.png#chivalry.png#crossbow-stirrups.png#enlistment-incentives.png#gambesons.png#long-guns.png#merchant-guilds-4.png#royal-bloodlines.png',
+        'technology_hre':
+            'benediction.png#devoutness.png#fire-stations.png#heavy-maces.png#inspired-warriors.png#marching-drills.png#reinforced-defenses.png#riveted-chain-mail-2.png#slate-and-stone-construction.png#steel-barding-3.png#two-handed-weapon.png',
+        'technology_japanese':
+            'bunrei.png#copper-plating-3.png#daimyo-manor-1.png#daimyo-palace-2.png#do-maru-armor-4.png#explosives-4.png#five_ministries.png#fudasashi-3.png#gion_festival.png#heated-shot-4.png#hizukuri-2.png#kabura-ya-whistling-arrow-3.png#kobuse-gitae-3.png#nagae-yari-4.png#nehan.png#oda-tactics-4.png#odachi-3.png#shinto_rituals.png#shogunate-castle-3.png#swivel-cannon-4.png#takezaiku-2.png#tatara-1.png#towara-1.png#yaki-ire-4.png#zen.png',
+        'technology_jeanne':
+            'companion-equipment-3.png#ordinance-company-3.png',
+        'technology_malians':
+            'banco-repairs-2.png#canoe-tactics-2.png#farima-leadership-4.png#imported-armor-3.png#local-knowledge-4.png#poisoned-arrows-3.png#precision-training-4.png',
+        'technology_military':
+            'angled-surfaces.png#balanced-projectiles.png#biology.png#bloomery.png#chemistry.png#damascus-steel.png#decarbonization.png#elite-army-tactics.png#fitted-leatherwork.png#geometry.png#greased-axles.png#incendiary-arrows.png#insulated-helm.png#iron-undermesh.png#master-smiths.png#military-academy.png#platecutter-point.png#siege-engineering.png#siege-works.png#steeled-arrow.png#wedge-rivets.png',
+        'technology_mongols':
+            'additional-torches.png#monastic-shrines.png#piracy.png#raid-bounty.png#siha-bow-limbs.png#steppe-lancers.png#stone-bounty.png#stone-commerce.png#superior-mobility.png#whistling-arrows.png#yam-network.png',
+        'technology_naval':
+            'additional-sails.png#armored-hull.png#chaser-cannons.png#explosives.png#extra-ballista.png#incendiaries-3.png#naval-arrow-slits.png#navigator-lookout.png#shipwrights-4.png#springald-crews-3.png',
+        'technology_ottomans':
+            'advanced-academy-1.png#anatolian-hills-1.png#fast-training-1.png#field-work-1.png#great-bombard-emplacement.png#imperial-fleet-4.png#janissary-company-1.png#janissary-guns-4.png#mehter-drums-1.png#military-campus-1.png#siege-crews-1.png#trade-bags-1.png',
+        'technology_religious': 'herbal-medicine.png#piety.png#tithe-barns.png',
+        'technology_rus':
+            'adaptable-hulls-3.png#banded-arms.png#blessing-duration.png#boyars-fortitude.png#castle-turret.png#castle-watch.png#cedar-hulls.png#clinker-construction.png#double-time.png#fine-tuned-guns.png#improved-blessing.png#knight-sabers.png#mounted-training.png#saints-reach.png#saints-veneration-4.png#siege-crew-training.png#wandering-town.png#warrior_scout_2.png',
+        'technology_units':
+            'adjustable-crossbars.png#lightweight-beams-4.png#roller-shutter-triggers.png#spyglass-4.png',
+        'technology_zhuxi':
+            '10000-bolts-4.png#advanced-administration-4.png#cloud-of-terror-4.png#dynastic-protectors-4.png#imperial-red-seals-3.png#military-affairs-bureau-1.png#roar-of-the-dragon-4.png',
+        'unit_abbasid':
+            'camel-archer-2.png#camel-rider-3.png#ghulam-3.png#imam.png',
+        'unit_ayyubids':
+            'atabeg-1.png#bedouin-skirmisher-2.png#bedouin-swordsman-1.png#camel-lancer-3.png#dervish-3.png#desert-raider-2.png#manjaniq-3.png#tower-of-the-sultan-3.png',
+        'unit_byzantines':
+            'arbaletrier-3.png#camel-archer-2.png#camel-rider-3.png#cataphract-3.png#cheirosiphon-3.png#desert-raider-2.png#dromon-2.png#ghulam-3.png#grenadier-4.png#horse-archer-3.png#javelin-thrower-2.png#keshik-2.png#landsknecht-3.png#limitanei-1.png#longbowman-2.png#mangudai.png#musofadi-warrior-2.png#royal-knight-2.png#sipahi-2.png#streltsy.png#tower-elephant-3.png#tower-of-the-sultan-3.png#varangian-guard-3.png#war-elephant.png#zhuge-nu-2.png',
+        'unit_cavalry':
+            'horseman-1.png#knight-2.png#lancer-3.png#lancer-4.png#scout.png',
+        'unit_chinese':
+            'fire-lancer-3.png#grenadier-4.png#imperial-official.png#junk.png#nest-of-bees.png#palace-guard-3.png#zhuge-nu-2.png',
+        'unit_delhi':
+            'ghazi-raider-2.png#scholar.png#sultans-elite-tower-elephant-4.png#tower-elephant-3.png#war-elephant.png',
+        'unit_dragon':
+            'dragon-handcannoneer-4.png#gilded-archer-2.png#gilded-crossbowman-3.png#gilded-horseman-2.png#gilded-knight-3.png#gilded-landsknecht-3.png#gilded-man-at-arms-2.png#gilded-spearman-1.png',
+        'unit_english':
+            'king-2.png#longbowman-2.png#wynguard-army-1.png#wynguard-footmen-1.png#wynguard-raiders-1.png#wynguard-ranger-4.png',
+        'unit_events': 'land_monster.png#water_monster.png',
+        'unit_french':
+            'arbaletrier-3.png#cannon-4.png#galleass.png#royal-cannon-4.png#royal-culverin-4.png#royal-knight-2.png#royal-ribauldequin-4.png#war-cog.png',
+        'unit_hre': 'landsknecht-3.png#prelate.png',
+        'unit_infantry':
+            'archer-2.png#crossbowman-3.png#handcannoneer-4.png#man-at-arms-1.png#spearman-1.png',
+        'unit_japanese':
+            'atakebune-4.png#buddhist-monk-3.png#katana-bannerman-2.png#mounted-samurai-3.png#onna-bugeisha-2.png#onna-musha-3.png#ozutsu-4.png#samurai-1.png#shinobi-2.png#shinto-priest-3.png#uma-bannerman-2.png#yumi-ashigaru-2.png#yumi-bannerman-2.png',
+        'unit_jeanne':
+            'jeanne-darc-blast-cannon-4.png#jeanne-darc-hunter-2.png#jeanne-darc-knight-3.png#jeanne-darc-markswoman-4.png#jeanne-darc-mounted-archer-3.png#jeanne-darc-peasant-1.png#jeanne-darc-woman-at-arms-2.png#jeannes-champion-3.png#jeannes-rider-3.png',
+        'unit_malians':
+            'donso-1.png#hunting-canoe-2.png#javelin-thrower-2.png#musofadi-gunner-4.png#musofadi-warrior-2.png#sofa-2.png#war-canoe-2.png#warrior-scout-2.png',
+        'unit_mongols':
+            'huihui-pao-1.png#keshik-2.png#khan-1.png#khans-hunter.png#light-junk.png#mangudai.png#shaman.png#traction-trebuchet.png',
+        'unit_ottomans':
+            'grand-galley-4.png#great-bombard-4.png#janissary-3.png#mehter-2.png#scout-ship-2.png#sipahi-2.png',
+        'unit_religious': 'imam-3.png#monk-3.png',
+        'unit_rus':
+            'horse-archer-3.png#lodya-attack-ship.png#lodya-demolition-ship.png#lodya-fishing-boat.png#lodya-galley-3.png#lodya-trade-ship.png#lodya-transport-ship.png#militia-2.png#streltsy.png#warrior-monk.png',
+        'unit_ship':
+            'baghlah.png#baochuan.png#carrack.png#demolition-ship.png#dhow.png#explosive-dhow.png#explosive-junk.png#fishing-boat.png#galley.png#hulk.png#junk-3.png#light-junk-2.png#trade-ship.png#transport-ship.png#war-junk.png#xebec.png',
+        'unit_siege':
+            'battering-ram.png#bombard.png#culverin-4.png#mangonel-3.png#ribauldequin-4.png#siege-tower.png#springald.png#trebuchet.png',
+        'unit_worker':
+            'monk-3.png#trader.png#villager-abbasid.png#villager-china.png#villager-delhi.png#villager-japanese.png#villager-malians.png#villager-mongols.png#villager-ottomans.png#villager.png',
+        'unit_zhuxi':
+            'imperial-guard-1.png#shaolin-monk-3.png#yuan-raider-4.png'
+      };
 
   // Split each string (e.g. 'image_0#image_1#image_2') in a list of images.
   for (const [key, value] of Object.entries(imagesDict)) {
@@ -5015,7 +5015,7 @@ function getInstructionsAoE4() {
     'On age4builder.com, select a build order, click on the salamander icon, and paste the content below.'
   ];
   return contentArrayToDiv(
-    getArrayInstructions(true, selectFactionLines, externalBOLines));
+      getArrayInstructions(true, selectFactionLines, externalBOLines));
 }
 
 /**
@@ -5031,7 +5031,7 @@ function openSinglePanelPageAoE4() {
   let columnsDescription = [
     new SinglePanelColumn('time', common + 'icon/time.png'),
     new SinglePanelColumn(
-      'population_count', game + 'building_economy/house.png'),
+        'population_count', game + 'building_economy/house.png'),
     new SinglePanelColumn('villager_count', game + 'unit_worker/villager.png'),
     new SinglePanelColumn('resources/builder', resource + 'repair.png'),
     new SinglePanelColumn('resources/food', resource + 'resource_food.png'),
@@ -5095,22 +5095,22 @@ function getResourceLineAoM(currentStep) {
   const resources = currentStep.resources;
 
   if (isBOImageValid(resources, 'food', true) ||
-    isBOImageValid(resources, 'wood', true) ||
-    isBOImageValid(resources, 'gold', true) ||
-    isBOImageValid(resources, 'favor', true)) {
+      isBOImageValid(resources, 'wood', true) ||
+      isBOImageValid(resources, 'gold', true) ||
+      isBOImageValid(resources, 'favor', true)) {
     htmlString +=
-      getBOImageValue(resourceFolder + 'food.png', resources, 'food');
+        getBOImageValue(resourceFolder + 'food.png', resources, 'food');
     htmlString +=
-      getBOImageValue(resourceFolder + 'wood.png', resources, 'wood');
+        getBOImageValue(resourceFolder + 'wood.png', resources, 'wood');
     htmlString +=
-      getBOImageValue(resourceFolder + 'gold.png', resources, 'gold');
+        getBOImageValue(resourceFolder + 'gold.png', resources, 'gold');
     htmlString +=
-      getBOImageValue(resourceFolder + 'favor.png', resources, 'favor');
+        getBOImageValue(resourceFolder + 'favor.png', resources, 'favor');
   }
   htmlString += getBOImageValue(
-    resourceFolder + 'repair.png', resources, 'builder', true);
+      resourceFolder + 'repair.png', resources, 'builder', true);
   htmlString += getBOImageValue(
-    resourceFolder + 'worker.png', currentStep, 'worker_count', true);
+      resourceFolder + 'worker.png', currentStep, 'worker_count', true);
 
   // Age image
   const ageImage = {
@@ -5123,7 +5123,7 @@ function getResourceLineAoM(currentStep) {
 
   if (currentStep.age in ageImage) {
     htmlString +=
-      getBOImageHTML(gamePicturesFolder + 'age/' + ageImage[currentStep.age]);
+        getBOImageHTML(gamePicturesFolder + 'age/' + ageImage[currentStep.age]);
   }
 
   return htmlString;
@@ -5149,7 +5149,7 @@ function checkValidBuildOrderAoM(nameBOMessage) {
 
     // Check correct major god
     const validFactionRes =
-      checkValidFaction(BONameStr, 'major_god', true, false);
+        checkValidFaction(BONameStr, 'major_god', true, false);
     if (!validFactionRes[0]) {
       return validFactionRes;
     }
@@ -5188,15 +5188,15 @@ function getBOStepAoM(builOrderData) {
       'worker_count': ('worker_count' in data) ? data['worker_count'] : 0,
       'age': ('age' in data) ? data['age'] : 1,
       'resources': ('resources' in data) ?
-        data['resources'] :
-        { 'food': 0, 'wood': 0, 'gold': 0, 'favor': 0 },
+          data['resources'] :
+          {'food': 0, 'wood': 0, 'gold': 0, 'favor': 0},
       'notes': ['Note 1', 'Note 2']
     };
   } else {
     return {
       'worker_count': 0,
       'age': 1,
-      'resources': { 'food': 0, 'wood': 0, 'gold': 0, 'favor': 0 },
+      'resources': {'food': 0, 'wood': 0, 'gold': 0, 'favor': 0},
       'notes': ['Note 1', 'Note 2']
     };
   }
@@ -5288,7 +5288,7 @@ function evaluateBOTimingAoM(timeOffset) {
   if (Array.isArray(majorGodData)) {
     if (!majorGodData.length) {
       console.log(
-        'Warning: the array of \'major_god\' is empty, timing cannot be evaluated.')
+          'Warning: the array of \'major_god\' is empty, timing cannot be evaluated.')
       return;
     }
     pantheon = getPantheon(majorGodData[0]);
@@ -5322,7 +5322,7 @@ function evaluateBOTimingAoM(timeOffset) {
 
   if (!('build_order' in dataBO)) {
     console.log(
-      'Warning: the \'build_order\' field is missing from data when evaluating the timing.')
+        'Warning: the \'build_order\' field is missing from data when evaluating the timing.')
     return;
   }
 
@@ -5340,7 +5340,7 @@ function evaluateBOTimingAoM(timeOffset) {
     const resources = currentStep['resources'];
     if (workerCount < 0) {
       workerCount = Math.max(0, resources['wood']) +
-        Math.max(0, resources['food']) + Math.max(0, resources['gold']);
+          Math.max(0, resources['food']) + Math.max(0, resources['gold']);
       if (pantheon === 'Greeks') {  // Only Greeks villagers can gather favor
         workerCount += Math.max(0, resources['favor']);
       }
@@ -5359,7 +5359,7 @@ function evaluateBOTimingAoM(timeOffset) {
     // Check for TC technologies or special units in notes
     for (note of currentStep['notes']) {
       for (const [tcItemImage, tcItemTime] of Object.entries(
-        TCUnitTechnologies)) {
+               TCUnitTechnologies)) {
         if (note.includes('@' + tcItemImage + '@')) {
           stepTotalTime += tcItemTime;
         }
@@ -5368,8 +5368,8 @@ function evaluateBOTimingAoM(timeOffset) {
 
     // Next age
     const nextAge = (1 <= currentStep['age'] && currentStep['age'] <= 5) ?
-      currentStep['age'] :
-      currentAge;
+        currentStep['age'] :
+        currentAge;
     if (nextAge === currentAge + 1)  // researching next age up
     {
       stepTotalTime += getResearchAgeUpTimeAoM(currentAge);
@@ -5385,7 +5385,7 @@ function evaluateBOTimingAoM(timeOffset) {
     // Special case for last step
     // (add 1 sec to avoid displaying both at the same time).
     if ((currentStepID === stepCount - 1) && (stepCount >= 2) &&
-      (currentStep['time'] === buildOrderData[currentStepID - 1]['time'])) {
+        (currentStep['time'] === buildOrderData[currentStepID - 1]['time'])) {
       currentStep['time'] = buildOrderTimeToStr(Math.round(lastTimeSec + 1.0));
     }
   }
@@ -5399,101 +5399,101 @@ function evaluateBOTimingAoM(timeOffset) {
 function getImagesAoM() {
   // This is obtained using the 'python/utilities/list_images.py' script.
   const imagesDict =
-  {
-    'age':
-      'archaic_age.png#classical_age.png#heroic_age.png#mythic_age.png#wonder_age.png',
-    'animal':
-      'arctic_wolf.png#aurochs.png#baboon.png#bear.png#boar.png#caribou.png#chicken.png#cow.png#crocodile.png#crowned_crane.png#deer.png#elephant.png#elk.png#fish.png#gazelle.png#giraffe.png#goat.png#hippopotamus.png#hyena.png#lion.png#monkey.png#pig.png#polar_bear.png#rhinoceros.png#tiger.png#walrus.png#water_buffalo.png#wolf.png#zebra.png',
-    'armory':
-      'armory.png#ballistics.png#bronze_armor.png#bronze_shields.png#bronze_weapons.png#burning_pitch.png#copper_armor.png#copper_shields.png#copper_weapons.png#iron_armor.png#iron_shields.png#iron_weapons.png',
-    'atlanteans_building':
-      'counter-barracks.png#economic_guild.png#manor.png#military_barracks.png#mirror_tower.png#palace.png#sky_passage.png#time_shift.png#town_center_atlantean.png',
-    'atlanteans_civilian': 'caravan_atlantean.png#citizen.png',
-    'atlanteans_hero':
-      'arcus_hero.png#cheiroballista_hero.png#citizen_hero.png#contarius_hero.png#destroyer_hero.png#fanatic_hero.png#katapeltes_hero.png#murmillo_hero.png#oracle_hero.png#turma_hero.png',
-    'atlanteans_human':
-      'arcus.png#contarius.png#destroyer.png#fanatic.png#katapeltes.png#murmillo.png#oracle_unit.png#turma.png',
-    'atlanteans_minor_god':
-      'atlas.png#hekate.png#helios.png#hyperion.png#leto.png#oceanus.png#prometheus.png#rheia.png#theia.png',
-    'atlanteans_myth':
-      'argus.png#atlantean_titan.png#automaton.png#behemoth.png#caladria.png#centimanus.png#lampades.png#man_o_war.png#nereid.png#promethean.png#satyr.png#servant.png#stymphalian_bird.png',
-    'atlanteans_power':
-      'carnivora_power.png#chaos.png#deconstruction.png#gaia_forest.png#hesperides.png#implode.png#shockwave.png#spider_lair.png#tartarian_gate_power.png#traitor.png#valor.png#vortex.png',
-    'atlanteans_ship':
-      'bireme.png#fire_ship.png#fishing_ship_atlantean.png#siege_bireme.png#transport_ship_atlantean.png',
-    'atlanteans_siege': 'cheiroballista.png#fire_siphon.png',
-    'atlanteans_tech':
-      'alluvial_clay.png#asper_blood.png#bite_of_the_shark.png#celerity.png#channels.png#conscript_counter_soldiers.png#conscript_mainline_soldiers.png#conscript_palace_soldiers.png#empyrian_speed.png#eyes_of_atlas.png#focus.png#gemini.png#guardian_of_io.png#halo_of_the_sun.png#heart_of_the_titans.png#hephaestus_revenge.png#heroic_renewal.png#horns_of_consecration.png#lance_of_stone.png#lemuriandescendants.png#levy_counter_soldiers.png#levy_mainline_soldiers.png#levy_palace_soldiers.png#mythic_rejuvenation.png#orichalcum_mail.png#petrification.png#poseidons_secret.png#rheias_gift.png#safe_passage.png#temporal_chaos.png#titan_shield.png#volcanic_forge.png#weightless_mace.png',
-    'defensive':
-      'boiling_oil.png#bronze_wall.png#carrier_pigeons.png#citadel_wall.png#crenellations.png#fortified_wall.png#guard_tower_upgrade.png#improvement_ballista_tower.png#improvement_watch_tower.png#iron_wall.png#orichalkos_wall.png#sentry_tower.png#signal_fires.png#stone_wall.png#wooden_wall.png',
-    'dock':
-      'arrowship_cladding.png#champion_warships.png#conscript_sailors.png#dock.png#enclosed_deck.png#heavy_warships.png#heroic_fleet.png#naval_oxybeles.png#purse_seine.png#reinforced_ram.png#salt_amphora.png',
-    'economy':
-      'bow_saw.png#carpenters.png#flood_control.png#hand_axe.png#husbandry.png#irrigation.png#pickaxe.png#plow.png#quarry.png#shaft_mine.png#survival_equipment.png',
-    'egyptians_building':
-      'barracks.png#granary.png#lighthouse.png#lumber_camp.png#migdol_stronghold.png#mining_camp.png#monument_to_villagers.png#obelisk.png#siege_works.png#town_center_egyptian.png',
-    'egyptians_civilian': 'caravan_egyptian.png#laborer.png',
-    'egyptians_hero': 'pharaoh.png#priest.png',
-    'egyptians_human': 'axeman.png#camel_rider.png#chariot_archer.png#mercenary.png#mercenary_cavalry.png#slinger.png#spearman.png#war_elephant.png',
-    'egyptians_minor_god':
-      'anubis.png#bast.png#horus.png#nephthys.png#osiris.png#ptah.png#sekhmet.png#sobek.png#thoth.png',
-    'egyptians_myth':
-      'anubite.png#avenger.png#egyptian_titan.png#leviathan.png#mummy.png#petsuchos.png#phoenix.png#roc.png#scarab.png#scorpion_man.png#son_of_osiris.png#sphinx.png#wadjet.png#war_turtle.png',
-    'egyptians_power':
-      'ancestors.png#citadel_power.png#eclipse.png#locust_swarm.png#meteor.png#plague_of_serpents.png#prosperity.png#rain.png#shifting_sands.png#son_of_osiris_power.png#tornado.png#vision.png',
-    'egyptians_ship':
-      'fishing_ship_egyptian.png#kebenit.png#ramming_galley.png#transport_ship_egyptian.png#war_barge.png',
-    'egyptians_siege': 'catapult.png#siege_tower.png',
-    'egyptians_tech':
-      'adze_of_wepwawet.png#atef_crown.png#axe_of_vengeance.png#bone_bow.png#book_of_thoth.png#champion_axemen.png#champion_camel_riders.png#champion_chariot_archers.png#champion_slingers.png#champion_spearmen.png#champion_war_elephants.png#clairvoyance.png#conscript_barracks_soldiers.png#conscript_migdol_soldiers.png#crimson_linen.png#criosphinx.png#crocodilopolis.png#dark_water.png#desert_wind.png#electrum_bullets.png#feet_of_the_jackal.png#feral.png#flood_of_the_nile.png#force_of_the_west_wind.png#funeral_barge.png#funeral_rites.png#greatest_of_fifty.png#hands_of_the_pharaoh.png#heavy_axemen.png#heavy_camel_riders.png#heavy_chariot_archers.png#heavy_slingers.png#heavy_spearmen.png#heavy_war_elephants.png#hieracosphinx.png#leather_frame_shield.png#levy_barracks_soldiers.png#levy_migdol_soldiers.png#medium_axemen.png#medium_slingers.png#medium_spearmen.png#nebty.png#necropolis.png#new_kingdom.png#sacred_cats.png#scalloped_axe.png#serpent_spear.png#shaduf.png#skin_of_the_rhino.png#slings_of_the_sun.png#solar_barque - copy.png#solar_barque.png#spear_of_horus.png#spirit_of_maat.png#stones_of_red_linen.png#sundried_mud_brick.png#tusks_of_apedemak.png#valley_of_the_kings.png#city_of_the_dead.jpg',
-    'greeks_building':
-      'archery_range.png#fortress.png#granary.png#military_academy.png#stable.png#storehouse.png#town_center_greek.png#village_center_greeks.png',
-    'greeks_civilian': 'caravan_greek.png#villager_greek.png',
-    'greeks_hero':
-      'achilles.png#ajax_spc.png#atalanta.png#bellerophon.png#chiron.png#heracles.png#hippolyta.png#jason.png#odysseus.png#perseus.png#polyphemus.png#theseus.png',
-    'greeks_human':
-      'gastraphetoros.png#hetairos.png#hippeus.png#hoplite.png#hypaspist.png#militia.png#myrmidon.png#peltast.png#prodromos.png#toxotes.png',
-    'greeks_minor_god':
-      'aphrodite.png#apollo.png#ares.png#artemis.png#athena.png#dionysus.png#hephaestus.png#hera.png#hermes.png',
-    'greeks_myth':
-      'carcinos.png#centaur.png#chimera.png#colossus.png#cyclops.png#greek_titan.png#hippocampus.png#hydra.png#manticore.png#medusa.png#minotaur.png#nemean_lion.png#pegasus.png#scylla.png',
-    'greeks_power':
-      'bolt.png#bronze.png#ceasefire.png#curse.png#earthquake.png#lightning_storm.png#lure_power.png#pestilence.png#plenty_vault.png#restoration.png#sentinel_power.png#underworld_passage.png',
-    'greeks_ship':
-      'fishing_ship_greek.png#juggernaut.png#pentekonter.png#transport_ship_greek.png#trireme.png',
-    'greeks_siege': 'helepolis.png#petrobolos.png',
-    'greeks_tech':
-      'aegis_shield.png#anastrophe.png#argive_patronage.png#conscript_cavalry.png#conscript_infantry.png#conscript_ranged_soldiers.png#deimos_sword_of_dread.png#dionysia.png#divine_blood.png#enyos_bow_of_horror.png#face_of_the_gorgon.png#flames_of_typhon.png#forge_of_olympus.png#golden_apples.png#hand_of_talos.png#labyrinth_of_minos.png#levy_cavalry.png#levy_infantry.png#levy_ranged_soldiers.png#lord_of_horses.png#monstrous_rage.png#olympian_parentage.png#olympian_weapons.png#oracle.png#phobos_spear_of_panic.png#roar_of_orthus.png#sarissa.png#shafts_of_plague.png#shoulder_of_talos.png#spirited_charge.png#sun_ray.png#sylvan_lore.png#temple_of_healing.png#thracian_horses.png#trierarch.png#vaults_of_erebus.png#will_of_kronos.png#winged_messenger.png',
-    'major_god':
-      'freyr.png#gaia.png#hades.png#isis.png#kronos.png#loki.png#odin.png#oranos.png#poseidon.png#ra.png#set.png#thor.png#zeus.png',
-    'market': 'ambassadors.png#coinage.png#market.png#tax_collectors.png',
-    'norse_building':
-      'dwarven_armory.png#great_hall.png#hill_fort.png#longhouse.png#town_center_norse.png',
-    'norse_civilian':
-      'caravan_norse.png#dwarf.png#gatherer.png#ox_cart.png',
-    'norse_hero': 'godi.png#hersir.png',
-    'norse_human':
-      'berserk.png#hirdman.png#huskarl.png#jarl.png#raiding_cavalry.png#throwing_axeman.png',
-    'norse_minor_god':
-      'aegir.png#baldr.png#bragi.png#forseti.png#freyja.png#heimdall.png#hel.png#njord.png#skadi.png#tyr.png#ullr.png#vidar.png',
-    'norse_myth':
-      'battle_boar.png#draugr.png#einherjar.png#fafnir.png#fenris_wolf_brood.png#fimbulwinter_wolf.png#fire_giant.png#frost_giant.png#jormun_elver.png#kraken.png#mountain_giant.png#nidhogg_unit.png#norse_titan.png#raven.png#rock_giant.png#troll.png#valkyrie.png#walking_woods_unit.png',
-    'norse_power':
-      'asgardian_bastion.png#dwarven_mine.png#fimbulwinter.png#flaming_weapons.png#forest_fire.png#frost.png#great_hunt.png#gullinbursti.png#healing_spring_power.png#inferno.png#nidhogg.png#ragnarok.png#spy.png#tempest.png#undermine.png#walking_woods_power.png',
-    'norse_ship':
-      'dragon_ship.png#dreki.png#fishing_ship_norse.png#longboat.png#transport_ship_norse.png',
-    'norse_siege': 'ballista.png#portable_ram.png',
-    'norse_tech':
-      'arctic_winds.png#avenging_spirit.png#berserkergang.png#bravery.png#call_of_valhalla.png#cave_troll.png#conscript_great_hall_soldiers.png#conscript_hill_fort_soldiers.png#conscript_longhouse_soldiers.png#disablot.png#dragonscale_shields.png#dwarven_auger.png#dwarven_breastplate.png#dwarven_weapons.png#eyes_in_the_forest.png#feasts_of_renown.png#freyr\'s_gift.png#fury_of_the_fallen.png#gjallarhorn.png#granite_blood.png#granite_maw.png#grasp_of_ran.png#hall_of_thanes.png#hamask.png#hammer_of_thunder.png#huntress_axe.png#levy_great_hall_soldiers.png#levy_hill_fort_soldiers.png#levy_longhouse_soldiers.png#long_serpent.png#meteoric_iron_armor.png#nine_waves.png#rampage.png#rime.png#ring_giver.png#ring_oath.png#safeguard.png#servants_of_glory.png#sessrumnir.png#silent_resolve.png#sons_of_sleipnir.png#swine_array.png#thundering_hooves.png#thurisaz_rune.png#twilight_of_the_gods.png#valgaldr.png#winter_harvest.png#wrath_of_the_deep.png#ydalir.png',
-    'other': 'farm.png#house.png#relic.png#titan_gate.png#wonder.png',
-    'resource':
-      'berry.png#favor.png#food.png#gold.png#repair.png#tree.png#wood.png#worker.png',
-    'tech_military':
-      'champion_archers.png#champion_cavalry.png#champion_infantry.png#draft_horses.png#engineers.png#heavy_archers.png#heavy_cavalry.png#heavy_infantry.png#medium_archers.png#medium_cavalry.png#medium_infantry.png#norse_champion_infantry.png#norse_heavy_infantry.png#norse_medium_infantry.png',
-    'temple': 'omniscience.png#temple.png',
-    'town_center':
-      'architects.png#fortified_town_center.png#masons.png#town_center.png#village_center.png'
-  };
+      {
+        'age':
+            'archaic_age.png#classical_age.png#heroic_age.png#mythic_age.png#wonder_age.png',
+        'animal':
+            'arctic_wolf.png#aurochs.png#baboon.png#bear.png#boar.png#caribou.png#chicken.png#cow.png#crocodile.png#crowned_crane.png#deer.png#elephant.png#elk.png#fish.png#gazelle.png#giraffe.png#goat.png#hippopotamus.png#hyena.png#lion.png#monkey.png#pig.png#polar_bear.png#rhinoceros.png#tiger.png#walrus.png#water_buffalo.png#wolf.png#zebra.png',
+        'armory':
+            'armory.png#ballistics.png#bronze_armor.png#bronze_shields.png#bronze_weapons.png#burning_pitch.png#copper_armor.png#copper_shields.png#copper_weapons.png#iron_armor.png#iron_shields.png#iron_weapons.png',
+        'atlanteans_building':
+            'counter-barracks.png#economic_guild.png#manor.png#military_barracks.png#mirror_tower.png#palace.png#sky_passage.png#time_shift.png#town_center_atlantean.png',
+        'atlanteans_civilian': 'caravan_atlantean.png#citizen.png',
+        'atlanteans_hero':
+            'arcus_hero.png#cheiroballista_hero.png#citizen_hero.png#contarius_hero.png#destroyer_hero.png#fanatic_hero.png#katapeltes_hero.png#murmillo_hero.png#oracle_hero.png#turma_hero.png',
+        'atlanteans_human':
+            'arcus.png#contarius.png#destroyer.png#fanatic.png#katapeltes.png#murmillo.png#oracle_unit.png#turma.png',
+        'atlanteans_minor_god':
+            'atlas.png#hekate.png#helios.png#hyperion.png#leto.png#oceanus.png#prometheus.png#rheia.png#theia.png',
+        'atlanteans_myth':
+            'argus.png#atlantean_titan.png#automaton.png#behemoth.png#caladria.png#centimanus.png#lampades.png#man_o_war.png#nereid.png#promethean.png#satyr.png#servant.png#stymphalian_bird.png',
+        'atlanteans_power':
+            'carnivora_power.png#chaos.png#deconstruction.png#gaia_forest.png#hesperides.png#implode.png#shockwave.png#spider_lair.png#tartarian_gate_power.png#traitor.png#valor.png#vortex.png',
+        'atlanteans_ship':
+            'bireme.png#fire_ship.png#fishing_ship_atlantean.png#siege_bireme.png#transport_ship_atlantean.png',
+        'atlanteans_siege': 'cheiroballista.png#fire_siphon.png',
+        'atlanteans_tech':
+            'alluvial_clay.png#asper_blood.png#bite_of_the_shark.png#celerity.png#channels.png#conscript_counter_soldiers.png#conscript_mainline_soldiers.png#conscript_palace_soldiers.png#empyrian_speed.png#eyes_of_atlas.png#focus.png#gemini.png#guardian_of_io.png#halo_of_the_sun.png#heart_of_the_titans.png#hephaestus_revenge.png#heroic_renewal.png#horns_of_consecration.png#lance_of_stone.png#lemuriandescendants.png#levy_counter_soldiers.png#levy_mainline_soldiers.png#levy_palace_soldiers.png#mythic_rejuvenation.png#orichalcum_mail.png#petrification.png#poseidons_secret.png#rheias_gift.png#safe_passage.png#temporal_chaos.png#titan_shield.png#volcanic_forge.png#weightless_mace.png',
+        'defensive':
+            'boiling_oil.png#bronze_wall.png#carrier_pigeons.png#citadel_wall.png#crenellations.png#fortified_wall.png#guard_tower_upgrade.png#improvement_ballista_tower.png#improvement_watch_tower.png#iron_wall.png#orichalkos_wall.png#sentry_tower.png#signal_fires.png#stone_wall.png#wooden_wall.png',
+        'dock':
+            'arrowship_cladding.png#champion_warships.png#conscript_sailors.png#dock.png#enclosed_deck.png#heavy_warships.png#heroic_fleet.png#naval_oxybeles.png#purse_seine.png#reinforced_ram.png#salt_amphora.png',
+        'economy':
+            'bow_saw.png#carpenters.png#flood_control.png#hand_axe.png#husbandry.png#irrigation.png#pickaxe.png#plow.png#quarry.png#shaft_mine.png#survival_equipment.png',
+        'egyptians_building':
+            'barracks.png#granary.png#lighthouse.png#lumber_camp.png#migdol_stronghold.png#mining_camp.png#monument_to_villagers.png#obelisk.png#siege_works.png#town_center_egyptian.png',
+        'egyptians_civilian': 'caravan_egyptian.png#laborer.png',
+        'egyptians_hero': 'pharaoh.png#priest.png',
+        'egyptians_human': 'axeman.png#camel_rider.png#chariot_archer.png#mercenary.png#mercenary_cavalry.png#slinger.png#spearman.png#war_elephant.png',
+        'egyptians_minor_god':
+            'anubis.png#bast.png#horus.png#nephthys.png#osiris.png#ptah.png#sekhmet.png#sobek.png#thoth.png',
+        'egyptians_myth':
+            'anubite.png#avenger.png#egyptian_titan.png#leviathan.png#mummy.png#petsuchos.png#phoenix.png#roc.png#scarab.png#scorpion_man.png#son_of_osiris.png#sphinx.png#wadjet.png#war_turtle.png',
+        'egyptians_power':
+            'ancestors.png#citadel_power.png#eclipse.png#locust_swarm.png#meteor.png#plague_of_serpents.png#prosperity.png#rain.png#shifting_sands.png#son_of_osiris_power.png#tornado.png#vision.png',
+        'egyptians_ship':
+            'fishing_ship_egyptian.png#kebenit.png#ramming_galley.png#transport_ship_egyptian.png#war_barge.png',
+        'egyptians_siege': 'catapult.png#siege_tower.png',
+        'egyptians_tech':
+            'adze_of_wepwawet.png#atef_crown.png#axe_of_vengeance.png#bone_bow.png#book_of_thoth.png#champion_axemen.png#champion_camel_riders.png#champion_chariot_archers.png#champion_slingers.png#champion_spearmen.png#champion_war_elephants.png#clairvoyance.png#conscript_barracks_soldiers.png#conscript_migdol_soldiers.png#crimson_linen.png#criosphinx.png#crocodilopolis.png#dark_water.png#desert_wind.png#electrum_bullets.png#feet_of_the_jackal.png#feral.png#flood_of_the_nile.png#force_of_the_west_wind.png#funeral_barge.png#funeral_rites.png#greatest_of_fifty.png#hands_of_the_pharaoh.png#heavy_axemen.png#heavy_camel_riders.png#heavy_chariot_archers.png#heavy_slingers.png#heavy_spearmen.png#heavy_war_elephants.png#hieracosphinx.png#leather_frame_shield.png#levy_barracks_soldiers.png#levy_migdol_soldiers.png#medium_axemen.png#medium_slingers.png#medium_spearmen.png#nebty.png#necropolis.png#new_kingdom.png#sacred_cats.png#scalloped_axe.png#serpent_spear.png#shaduf.png#skin_of_the_rhino.png#slings_of_the_sun.png#solar_barque - copy.png#solar_barque.png#spear_of_horus.png#spirit_of_maat.png#stones_of_red_linen.png#sundried_mud_brick.png#tusks_of_apedemak.png#valley_of_the_kings.png#city_of_the_dead.jpg',
+        'greeks_building':
+            'archery_range.png#fortress.png#granary.png#military_academy.png#stable.png#storehouse.png#town_center_greek.png#village_center_greeks.png',
+        'greeks_civilian': 'caravan_greek.png#villager_greek.png',
+        'greeks_hero':
+            'achilles.png#ajax_spc.png#atalanta.png#bellerophon.png#chiron.png#heracles.png#hippolyta.png#jason.png#odysseus.png#perseus.png#polyphemus.png#theseus.png',
+        'greeks_human':
+            'gastraphetoros.png#hetairos.png#hippeus.png#hoplite.png#hypaspist.png#militia.png#myrmidon.png#peltast.png#prodromos.png#toxotes.png',
+        'greeks_minor_god':
+            'aphrodite.png#apollo.png#ares.png#artemis.png#athena.png#dionysus.png#hephaestus.png#hera.png#hermes.png',
+        'greeks_myth':
+            'carcinos.png#centaur.png#chimera.png#colossus.png#cyclops.png#greek_titan.png#hippocampus.png#hydra.png#manticore.png#medusa.png#minotaur.png#nemean_lion.png#pegasus.png#scylla.png',
+        'greeks_power':
+            'bolt.png#bronze.png#ceasefire.png#curse.png#earthquake.png#lightning_storm.png#lure_power.png#pestilence.png#plenty_vault.png#restoration.png#sentinel_power.png#underworld_passage.png',
+        'greeks_ship':
+            'fishing_ship_greek.png#juggernaut.png#pentekonter.png#transport_ship_greek.png#trireme.png',
+        'greeks_siege': 'helepolis.png#petrobolos.png',
+        'greeks_tech':
+            'aegis_shield.png#anastrophe.png#argive_patronage.png#conscript_cavalry.png#conscript_infantry.png#conscript_ranged_soldiers.png#deimos_sword_of_dread.png#dionysia.png#divine_blood.png#enyos_bow_of_horror.png#face_of_the_gorgon.png#flames_of_typhon.png#forge_of_olympus.png#golden_apples.png#hand_of_talos.png#labyrinth_of_minos.png#levy_cavalry.png#levy_infantry.png#levy_ranged_soldiers.png#lord_of_horses.png#monstrous_rage.png#olympian_parentage.png#olympian_weapons.png#oracle.png#phobos_spear_of_panic.png#roar_of_orthus.png#sarissa.png#shafts_of_plague.png#shoulder_of_talos.png#spirited_charge.png#sun_ray.png#sylvan_lore.png#temple_of_healing.png#thracian_horses.png#trierarch.png#vaults_of_erebus.png#will_of_kronos.png#winged_messenger.png',
+        'major_god':
+            'freyr.png#gaia.png#hades.png#isis.png#kronos.png#loki.png#odin.png#oranos.png#poseidon.png#ra.png#set.png#thor.png#zeus.png',
+        'market': 'ambassadors.png#coinage.png#market.png#tax_collectors.png',
+        'norse_building':
+            'dwarven_armory.png#great_hall.png#hill_fort.png#longhouse.png#town_center_norse.png',
+        'norse_civilian':
+            'caravan_norse.png#dwarf.png#gatherer.png#ox_cart.png',
+        'norse_hero': 'godi.png#hersir.png',
+        'norse_human':
+            'berserk.png#hirdman.png#huskarl.png#jarl.png#raiding_cavalry.png#throwing_axeman.png',
+        'norse_minor_god':
+            'aegir.png#baldr.png#bragi.png#forseti.png#freyja.png#heimdall.png#hel.png#njord.png#skadi.png#tyr.png#ullr.png#vidar.png',
+        'norse_myth':
+            'battle_boar.png#draugr.png#einherjar.png#fafnir.png#fenris_wolf_brood.png#fimbulwinter_wolf.png#fire_giant.png#frost_giant.png#jormun_elver.png#kraken.png#mountain_giant.png#nidhogg_unit.png#norse_titan.png#raven.png#rock_giant.png#troll.png#valkyrie.png#walking_woods_unit.png',
+        'norse_power':
+            'asgardian_bastion.png#dwarven_mine.png#fimbulwinter.png#flaming_weapons.png#forest_fire.png#frost.png#great_hunt.png#gullinbursti.png#healing_spring_power.png#inferno.png#nidhogg.png#ragnarok.png#spy.png#tempest.png#undermine.png#walking_woods_power.png',
+        'norse_ship':
+            'dragon_ship.png#dreki.png#fishing_ship_norse.png#longboat.png#transport_ship_norse.png',
+        'norse_siege': 'ballista.png#portable_ram.png',
+        'norse_tech':
+            'arctic_winds.png#avenging_spirit.png#berserkergang.png#bravery.png#call_of_valhalla.png#cave_troll.png#conscript_great_hall_soldiers.png#conscript_hill_fort_soldiers.png#conscript_longhouse_soldiers.png#disablot.png#dragonscale_shields.png#dwarven_auger.png#dwarven_breastplate.png#dwarven_weapons.png#eyes_in_the_forest.png#feasts_of_renown.png#freyr\'s_gift.png#fury_of_the_fallen.png#gjallarhorn.png#granite_blood.png#granite_maw.png#grasp_of_ran.png#hall_of_thanes.png#hamask.png#hammer_of_thunder.png#huntress_axe.png#levy_great_hall_soldiers.png#levy_hill_fort_soldiers.png#levy_longhouse_soldiers.png#long_serpent.png#meteoric_iron_armor.png#nine_waves.png#rampage.png#rime.png#ring_giver.png#ring_oath.png#safeguard.png#servants_of_glory.png#sessrumnir.png#silent_resolve.png#sons_of_sleipnir.png#swine_array.png#thundering_hooves.png#thurisaz_rune.png#twilight_of_the_gods.png#valgaldr.png#winter_harvest.png#wrath_of_the_deep.png#ydalir.png',
+        'other': 'farm.png#house.png#relic.png#titan_gate.png#wonder.png',
+        'resource':
+            'berry.png#favor.png#food.png#gold.png#repair.png#tree.png#wood.png#worker.png',
+        'tech_military':
+            'champion_archers.png#champion_cavalry.png#champion_infantry.png#draft_horses.png#engineers.png#heavy_archers.png#heavy_cavalry.png#heavy_infantry.png#medium_archers.png#medium_cavalry.png#medium_infantry.png#norse_champion_infantry.png#norse_heavy_infantry.png#norse_medium_infantry.png',
+        'temple': 'omniscience.png#temple.png',
+        'town_center':
+            'architects.png#fortified_town_center.png#masons.png#town_center.png#village_center.png'
+      };
 
   // Split each string (e.g. 'image_0#image_1#image_2') in a list of images.
   for (const [key, value] of Object.entries(imagesDict)) {
@@ -5631,11 +5631,11 @@ function getResourceLineSC2(currentStep) {
   const resourceFolder = gamePicturesFolder + 'resource/';
 
   htmlString += getBOImageValue(
-    resourceFolder + 'minerals.png', currentStep, 'minerals', true);
+      resourceFolder + 'minerals.png', currentStep, 'minerals', true);
   htmlString += getBOImageValue(
-    resourceFolder + 'vespene_gas.png', currentStep, 'vespene_gas', true);
+      resourceFolder + 'vespene_gas.png', currentStep, 'vespene_gas', true);
   htmlString += getBOImageValue(
-    commonPicturesFolder + 'icon/house.png', currentStep, 'supply', true);
+      commonPicturesFolder + 'icon/house.png', currentStep, 'supply', true);
 
   return htmlString;
 }
@@ -5665,7 +5665,7 @@ function checkValidBuildOrderSC2(nameBOMessage) {
     }
 
     const validOpponentRaceRes =
-      checkValidFaction(BONameStr, 'opponent_race', true);
+        checkValidFaction(BONameStr, 'opponent_race', true);
     if (!validOpponentRaceRes[0]) {
       return validOpponentRaceRes;
     }
@@ -5739,30 +5739,30 @@ function getBOTemplateSC2() {
 function getImagesSC2() {
   // This is obtained using the 'python/utilities/list_images.py' script.
   const
-    imagesDict =
-    {
-      'protoss_buildings':
-        'Assimilator.png#Cybernetics_Core.png#Dark_Shrine.png#Fleet_Beacon.png#Forge.png#Gateway.png#Nexus.png#Photon_Cannon.png#Pylon.png#Robotics_Bay.png#Robotics_Facility.png#ShieldBattery.png#Stargate.png#StasisWard.png#Templar_Archives.png#Twilight_Council.png#Warp_Gate.png',
-      'protoss_techs':
-        'Air_armor_1.png#Air_armor_2.png#Air_armor_3.png#Air_weapons_1.png#Air_weapons_2.png#Air_weapons_3.png#Anion_Pulse-Crystals.png#Battery_Overcharge.png#Blink.png#Charge.png#Chrono_boost.png#Extended_thermal_lances.png#Flux_Vanes.png#Gravitic_booster.png#Gravitic_drive.png#Graviton_catapult.png#Ground_armor_1.png#Ground_armor_2.png#Ground_armor_3.png#Ground_weapons_1.png#Ground_weapons_2.png#Ground_weapons_3.png#Guardian_shield.png#Mass_Recall.png#Psionic_storm.png#Resonating_Glaives.png#Shadow_Stride.png#Shields_1.png#Shields_2.png#Shields_3.png#Tectonic_Destabilizers.png#Transform_warpgate.png',
-      'protoss_units':
-        'Adept.png#Archon.png#Carrier.png#Colossus.png#Dark_Templar.png#Disruptor.png#High_Templar.png#Immortal.png#Mothership.png#Mothership_Core.png#Observer.png#Oracle.png#Phoenix.png#Probe.png#Sentry.png#Stalker.png#Tempest.png#VoidRay.png#Warp_Prism.png#Zealot.png',
-      'race_icon':
-        'AnyRaceIcon.png#ProtossIcon.png#TerranIcon.png#ZergIcon.png',
-      'resource': 'minerals.png#vespene_gas.png',
-      'terran_buildings':
-        'Armory.png#Barracks.png#Bunker.png#CommandCenter.png#EngineeringBay.png#Factory.png#FusionCore.png#GhostAcademy.png#MissileTurret.png#OrbitalCommand.png#PlanetaryFortress.png#Reactor.png#Refinery.png#SensorTower.png#Starport.png#SupplyDepot.png#TechLab.png',
-      'terran_techs':
-        'Advanced_Ballistics.png#Behemoth_reactor.png#Building_armor.png#Build_Reactor.png#Build_Tech_Lab.png#Calldown_extra_supplies.png#Calldown_mule.png#Cloak.png#Enhanced_Shockwaves.png#High_Capacity_Fuel_Tanks.png#Hisec_auto_tracking.png#Infantry_armor_1.png#Infantry_armor_2.png#Infantry_armor_3.png#Infantry_weapons_1.png#Infantry_weapons_2.png#Infantry_weapons_3.png#Lower.png#Moebius_reactor.png#Neosteel_frames.png#Nuke.png#Scanner_sweep.png#Ship_weapons_1.png#Ship_weapons_2.png#Ship_weapons_3.png#Vehicle_plating_1.png#Vehicle_plating_2.png#Vehicle_plating_3.png#Vehicle_weapons_1.png#Vehicle_weapons_2.png#Vehicle_weapons_3.png#Yamato_cannon.png',
-      'terran_units':
-        'Auto-turret.png#Banshee.png#Battlecruiser.png#Cyclone.png#Ghost.png#Hellbat.png#Hellion.png#Liberator.png#Marauder.png#Marine.png#Medivac.png#MULE.png#Point_defense_drone.png#Raven.png#Reaper.png#SCV.png#SiegeTank.png#Thor.png#Viking.png#WidowMine.png',
-      'zerg_buildings':
-        'Baneling_Nest.png#Creep_Tumor.png#Evolution_Chamber.png#Extractor.png#Greater_Spire.png#Hatchery.png#Hive.png#Hydralisk_Den.png#Infestation_Pit.png#Lair.png#LurkerDen.png#Nydus_Network.png#Nydus_Worm.png#Roach_Warren.png#Spawning_Pool.png#Spine_Crawler.png#Spire.png#Spore_Crawler.png#Ultralisk_Cavern.png',
-      'zerg_techs':
-        'Adaptive_Talons.png#Adrenal_glands.png#Anabolic_Synthesis.png#Burrow.png#Centrifugal_hooks.png#Chitinous_Plating.png#Flyer_attack_1.png#Flyer_attack_2.png#Flyer_attack_3.png#Flyer_carapace_1.png#Flyer_carapace_2.png#Flyer_carapace_3.png#Glial_reconstitution.png#Grooved_Spines.png#Ground_carapace_1.png#Ground_carapace_2.png#Ground_carapace_3.png#Melee_attacks_1.png#Melee_attacks_2.png#Melee_attacks_3.png#Metabolic_boost.png#Microbial_Shroud.png#Missile_attacks_1.png#Missile_attacks_2.png#Missile_attacks_3.png#Muscular_Augments.png#Mutate_Ventral_Sacs.png#Neural_parasite.png#Pathogen_glands.png#Pneumatized_carapace.png#Seismic_Spines.png#Tunneling_claws.png',
-      'zerg_units':
-        'Baneling.png#Broodling.png#Brood_Lord.png#Changeling.png#Corruptor.png#Drone.png#Hydralisk.png#Infested_Terran.png#Infestor.png#Larva.png#Lurker.png#Mutalisk.png#Overlord.png#Overseer.png#Queen.png#Ravager.png#Roach.png#Swarm_Host.png#Ultralisk.png#Viper.png#Zergling.png'
-    };
+      imagesDict =
+          {
+            'protoss_buildings':
+                'Assimilator.png#Cybernetics_Core.png#Dark_Shrine.png#Fleet_Beacon.png#Forge.png#Gateway.png#Nexus.png#Photon_Cannon.png#Pylon.png#Robotics_Bay.png#Robotics_Facility.png#ShieldBattery.png#Stargate.png#StasisWard.png#Templar_Archives.png#Twilight_Council.png#Warp_Gate.png',
+            'protoss_techs':
+                'Air_armor_1.png#Air_armor_2.png#Air_armor_3.png#Air_weapons_1.png#Air_weapons_2.png#Air_weapons_3.png#Anion_Pulse-Crystals.png#Battery_Overcharge.png#Blink.png#Charge.png#Chrono_boost.png#Extended_thermal_lances.png#Flux_Vanes.png#Gravitic_booster.png#Gravitic_drive.png#Graviton_catapult.png#Ground_armor_1.png#Ground_armor_2.png#Ground_armor_3.png#Ground_weapons_1.png#Ground_weapons_2.png#Ground_weapons_3.png#Guardian_shield.png#Mass_Recall.png#Psionic_storm.png#Resonating_Glaives.png#Shadow_Stride.png#Shields_1.png#Shields_2.png#Shields_3.png#Tectonic_Destabilizers.png#Transform_warpgate.png',
+            'protoss_units':
+                'Adept.png#Archon.png#Carrier.png#Colossus.png#Dark_Templar.png#Disruptor.png#High_Templar.png#Immortal.png#Mothership.png#Mothership_Core.png#Observer.png#Oracle.png#Phoenix.png#Probe.png#Sentry.png#Stalker.png#Tempest.png#VoidRay.png#Warp_Prism.png#Zealot.png',
+            'race_icon':
+                'AnyRaceIcon.png#ProtossIcon.png#TerranIcon.png#ZergIcon.png',
+            'resource': 'minerals.png#vespene_gas.png',
+            'terran_buildings':
+                'Armory.png#Barracks.png#Bunker.png#CommandCenter.png#EngineeringBay.png#Factory.png#FusionCore.png#GhostAcademy.png#MissileTurret.png#OrbitalCommand.png#PlanetaryFortress.png#Reactor.png#Refinery.png#SensorTower.png#Starport.png#SupplyDepot.png#TechLab.png',
+            'terran_techs':
+                'Advanced_Ballistics.png#Behemoth_reactor.png#Building_armor.png#Build_Reactor.png#Build_Tech_Lab.png#Calldown_extra_supplies.png#Calldown_mule.png#Cloak.png#Enhanced_Shockwaves.png#High_Capacity_Fuel_Tanks.png#Hisec_auto_tracking.png#Infantry_armor_1.png#Infantry_armor_2.png#Infantry_armor_3.png#Infantry_weapons_1.png#Infantry_weapons_2.png#Infantry_weapons_3.png#Lower.png#Moebius_reactor.png#Neosteel_frames.png#Nuke.png#Scanner_sweep.png#Ship_weapons_1.png#Ship_weapons_2.png#Ship_weapons_3.png#Vehicle_plating_1.png#Vehicle_plating_2.png#Vehicle_plating_3.png#Vehicle_weapons_1.png#Vehicle_weapons_2.png#Vehicle_weapons_3.png#Yamato_cannon.png',
+            'terran_units':
+                'Auto-turret.png#Banshee.png#Battlecruiser.png#Cyclone.png#Ghost.png#Hellbat.png#Hellion.png#Liberator.png#Marauder.png#Marine.png#Medivac.png#MULE.png#Point_defense_drone.png#Raven.png#Reaper.png#SCV.png#SiegeTank.png#Thor.png#Viking.png#WidowMine.png',
+            'zerg_buildings':
+                'Baneling_Nest.png#Creep_Tumor.png#Evolution_Chamber.png#Extractor.png#Greater_Spire.png#Hatchery.png#Hive.png#Hydralisk_Den.png#Infestation_Pit.png#Lair.png#LurkerDen.png#Nydus_Network.png#Nydus_Worm.png#Roach_Warren.png#Spawning_Pool.png#Spine_Crawler.png#Spire.png#Spore_Crawler.png#Ultralisk_Cavern.png',
+            'zerg_techs':
+                'Adaptive_Talons.png#Adrenal_glands.png#Anabolic_Synthesis.png#Burrow.png#Centrifugal_hooks.png#Chitinous_Plating.png#Flyer_attack_1.png#Flyer_attack_2.png#Flyer_attack_3.png#Flyer_carapace_1.png#Flyer_carapace_2.png#Flyer_carapace_3.png#Glial_reconstitution.png#Grooved_Spines.png#Ground_carapace_1.png#Ground_carapace_2.png#Ground_carapace_3.png#Melee_attacks_1.png#Melee_attacks_2.png#Melee_attacks_3.png#Metabolic_boost.png#Microbial_Shroud.png#Missile_attacks_1.png#Missile_attacks_2.png#Missile_attacks_3.png#Muscular_Augments.png#Mutate_Ventral_Sacs.png#Neural_parasite.png#Pathogen_glands.png#Pneumatized_carapace.png#Seismic_Spines.png#Tunneling_claws.png',
+            'zerg_units':
+                'Baneling.png#Broodling.png#Brood_Lord.png#Changeling.png#Corruptor.png#Drone.png#Hydralisk.png#Infested_Terran.png#Infestor.png#Larva.png#Lurker.png#Mutalisk.png#Overlord.png#Overseer.png#Queen.png#Ravager.png#Roach.png#Swarm_Host.png#Ultralisk.png#Viper.png#Zergling.png'
+          };
 
   // Split each string (e.g. 'image_0#image_1#image_2') in a list of images.
   for (const [key, value] of Object.entries(imagesDict)) {

--- a/docs/rts_overlay.js
+++ b/docs/rts_overlay.js
@@ -1256,19 +1256,21 @@ function initConfigWindow() {
 
   // Get the requested game from the URL options
   const params = new URLSearchParams(new URL(window.location.href).search);
-  const urlOptions = params.keys().next().value;
 
-  if (urlOptions) {
-    const arrayOptions = urlOptions.split('|');
+  // Select the game
+  const urlGameId = params.get('gameId');
+  if (urlGameId) {
+    updateGameWithName(urlGameId);
+  }
 
-    // Select the game
-    if (arrayOptions.length >= 1) {
-      updateGameWithName(arrayOptions[0]);
-    }
-    // Fetch a build order from an external API
-    if (arrayOptions.length >= 3) {
-      if ((gameName === 'aoe4') && (arrayOptions[1] === 'aoe4guides')) {
-        const apiUrl = 'https://aoe4guides.com/api/builds/' + arrayOptions[2] +
+  // Fetch a build order from an external API
+  const urlBuildOrderId = params.get('buildOrderId');
+  if (urlBuildOrderId) {
+    const arrayOptions = urlBuildOrderId.split('|');
+
+    if (arrayOptions.length == 2) {
+      if ((gameName === 'aoe4') && (arrayOptions[0] === 'aoe4guides')) {
+        const apiUrl = 'https://aoe4guides.com/api/builds/' + arrayOptions[1] +
             '?overlay=true';
 
         getBOFromApi(apiUrl).then(result => {

--- a/docs/rts_overlay.js
+++ b/docs/rts_overlay.js
@@ -1224,6 +1224,29 @@ function updateGame() {
 }
 
 /**
+ * Get a build order from an API url.
+ *
+ * @param {string} apiUrl  API url providing the requested BO.
+ *
+ * @returns String with BO as JSON content, null if error happened.
+ */
+function getBOFromApi(apiUrl) {
+  return fetch(apiUrl)
+      .then(response => {
+        if (!response.ok) {
+          throw new Error(
+              'Could not fetch data from ' + apiUrl + ' | ' + response.status);
+        }
+        return response.json();
+      })
+      .then(data => JSON.stringify(data, null, 4))
+      .catch(error => {
+        console.error('Fetch error: ' + error);
+        return null;
+      });
+}
+
+/**
  * Initialize the configuration window.
  */
 function initConfigWindow() {
@@ -1234,7 +1257,32 @@ function initConfigWindow() {
   // Get the requested game from the URL options
   const params = new URLSearchParams(new URL(window.location.href).search);
   const urlOptions = params.keys().next().value;
-  updateGameWithName(urlOptions);
+
+  if (urlOptions) {
+    const arrayOptions = urlOptions.split('|');
+
+    // Select the game
+    if (arrayOptions.length >= 1) {
+      updateGameWithName(arrayOptions[0]);
+    }
+    // Fetch a build order from an external API
+    if (arrayOptions.length >= 3) {
+      if ((gameName === 'aoe4') && (arrayOptions[1] === 'aoe4guides')) {
+        const apiUrl = 'https://aoe4guides.com/api/builds/' + arrayOptions[2] +
+            '?overlay=true';
+
+        getBOFromApi(apiUrl).then(result => {
+          if (result) {
+            document.getElementById('bo_design').value = result;
+            updateDataBO();
+            updateBOPanel(false);
+          } else {
+            console.log('Could not fetch the build order from aoe4guides.com.');
+          }
+        });
+      }
+    }
+  }
 
   // Get the images available
   imagesCommon = getImagesCommon();

--- a/docs/rts_overlay.js
+++ b/docs/rts_overlay.js
@@ -1166,6 +1166,8 @@ function updateBOFromWidgets() {
  * Update the game and corresponding variables from its short name.
  *
  * @param {string} newGameName  Short name of the game (e.g. 'aoe2').
+ *
+ * @return true if game name found and updated, false if no update.
  */
 function updateGameWithName(newGameName) {
   let selectGame = document.getElementById('select_game');
@@ -1178,10 +1180,11 @@ function updateGameWithName(newGameName) {
       gameFullName = selectGame.options[i].text;
 
       updateGame(); // Update the other variables
-      return;
+      return true;
     }
   }
-  console.log('Warning: no game found with the name \'' + newGameName + '\'.');
+
+  return false;
 }
 
 /**
@@ -1189,41 +1192,10 @@ function updateGameWithName(newGameName) {
  * The variables 'gameName' and 'gameFullName' must already be defined.
  */
 function updateGame() {
-  imagesGame = getImagesGame();
-  factionsList = getFactions();
-  factionImagesFolder = getFactionImagesFolder();
-
-  updateMainConfigSelection();
-  updateExternalBOWebsites();
-  updateRTSOverlayInfo();
-  initImagesSelection();
-  initBOFactionSelection();
-  readLibrary();
-  updateLibrarySearch();
-
-  resetDataBOMsg();
-  document.getElementById('bo_design').value = getWelcomeMessage();
-  updateSalamanderIcon();
-
-  showHideItems();
-}
-
-/**
- * Initialize the configuration window.
- */
-function initConfigWindow() {
-  // Pre-load error image (for potential installation)
-  let preloadErrorImager = new Image();
-  preloadErrorImager.src = ERROR_IMAGE;
-
   // Get the images available
   imagesGame = getImagesGame();
-  imagesCommon = getImagesCommon();
   factionsList = getFactions();
   factionImagesFolder = getFactionImagesFolder();
-
-  // Update the title of the configuration page
-  updateTitle();
 
   // Update the main configuration selection
   updateMainConfigSelection();
@@ -1242,14 +1214,37 @@ function initConfigWindow() {
   readLibrary();
   updateLibrarySearch();
 
-  // Update the hotkeys tooltip for 'Diplay overlay'
-  document.getElementById('diplay_overlay_tooltiptext').innerHTML =
-    getDiplayOverlayTooltiptext();
-
   // Initialize the BO panel
   resetDataBOMsg();
   document.getElementById('bo_design').value = getWelcomeMessage();
   updateSalamanderIcon();
+
+  // Show or hide elements
+  showHideItems();
+}
+
+/**
+ * Initialize the configuration window.
+ */
+function initConfigWindow() {
+  // Pre-load error image (for potential installation)
+  let preloadErrorImager = new Image();
+  preloadErrorImager.src = ERROR_IMAGE;
+
+  // Get the requested game from the URL options
+  const params = new URLSearchParams(new URL(window.location.href).search);
+  const urlOptions = params.keys().next().value;
+  updateGameWithName(urlOptions);
+
+  // Get the images available
+  imagesCommon = getImagesCommon();
+
+  // Update the title of the configuration page
+  updateTitle();
+
+  // Update the hotkeys tooltip for 'Diplay overlay'
+  document.getElementById('diplay_overlay_tooltiptext').innerHTML =
+    getDiplayOverlayTooltiptext();
 
   // Set default sliders values
   document.getElementById('bo_fontsize').value = DEFAULT_BO_PANEL_FONTSIZE;
@@ -1259,8 +1254,8 @@ function initConfigWindow() {
     DEFAULT_OVERLAY_ON_RIGHT_SIDE;
   updateBOFromWidgets();
 
-  // Show or hide elements
-  showHideItems();
+  // Update elements depending on the selected game
+  updateGame();
 
   // Updating the variables when changing the game
   document.getElementById('select_game').addEventListener('input', function () {

--- a/docs/rts_overlay.js
+++ b/docs/rts_overlay.js
@@ -56,10 +56,10 @@ const EXTERNAL_BO_WEBSITES = {
 
 // Fields of the faction name: player and (optionally) opponent
 const FACTION_FIELD_NAMES = {
-  'aoe2': {'player': 'civilization', 'opponent': null},
-  'aoe4': {'player': 'civilization', 'opponent': null},
-  'aom': {'player': 'major_god', 'opponent': null},
-  'sc2': {'player': 'race', 'opponent': 'opponent_race'}
+  'aoe2': { 'player': 'civilization', 'opponent': null },
+  'aoe4': { 'player': 'civilization', 'opponent': null },
+  'aom': { 'player': 'major_god', 'opponent': null },
+  'sc2': { 'player': 'race', 'opponent': 'opponent_race' }
 };
 
 // List of games where each step starts at the given time
@@ -73,7 +73,7 @@ const TIMER_SPEED_FACTOR = {
 // Special cases for the max number of images per row
 // (MAX_ROW_SELECT_IMAGES otherwise).
 const SPECIAL_MAX_ROW_SELECT_IMAGES = {
-  'aoe4': {'select faction': 8, 'civilization_flag': 12}
+  'aoe4': { 'select faction': 8, 'civilization_flag': 12 }
 };
 
 // Image to display when the requested image can not be loaded
@@ -104,7 +104,7 @@ let bo_panel_font_size = DEFAULT_BO_PANEL_FONTSIZE;
 let imageHeightBO = DEFAULT_BO_PANEL_IMAGES_SIZE;
 // Height of the action buttons.
 let actionButtonHeight =
-    ACTION_BUTTON_HEIGHT_RATIO * DEFAULT_BO_PANEL_IMAGES_SIZE;
+  ACTION_BUTTON_HEIGHT_RATIO * DEFAULT_BO_PANEL_IMAGES_SIZE;
 // Overlay on right or left side of the screen.
 let overlayOnRightSide = DEFAULT_OVERLAY_ON_RIGHT_SIDE;
 
@@ -113,10 +113,10 @@ let buildOrderTimer = {
   'step_starting_flag': false,  // true if the timer steps starts at the
   // indicated time, false if ending at this time
   'use_timer':
-      false,  // true to update BO with timer, false for manual selection
+    false,  // true to update BO with timer, false for manual selection
   'run_timer': false,  // true if the BO timer is running (false to stop)
   'absolute_time_init':
-      0.0,             // last absolute time when the BO timer run started [sec]
+    0.0,             // last absolute time when the BO timer run started [sec]
   'time_sec': 0.0,     // time for the BO [sec]
   'time_int': 0,       // 'time_sec' with a cast to integer
   'last_time_int': 0,  // last value for 'time_int' [sec]
@@ -196,9 +196,9 @@ function overlayResizeMove() {
 
   // Check if width/height require a change
   const widthFlag = (newWidth > currentWidth) ||
-      (newWidth < currentWidth - SIZE_UPDATE_THRESHOLD);
+    (newWidth < currentWidth - SIZE_UPDATE_THRESHOLD);
   const heightFlag = (newHeight > currentHeight) ||
-      (newHeight < currentHeight - SIZE_UPDATE_THRESHOLD);
+    (newHeight < currentHeight - SIZE_UPDATE_THRESHOLD);
 
   // Apply modifications if at least one dimension requires an update
   if (widthFlag || heightFlag) {
@@ -331,7 +331,7 @@ function getImagePath(imageSearch) {
     for (let image of images) {
       if (imageSearch === subFolder + '/' + image) {
         return 'assets/common' +
-            '/' + imageSearch;
+          '/' + imageSearch;
       }
     }
   }
@@ -355,8 +355,8 @@ function getImagePath(imageSearch) {
  * @returns Requested HTML code.
  */
 function getImageHTML(
-    imagePath, imageHeight, functionName = null, functionArgs = null,
-    tooltipText = null, imageID = null) {
+  imagePath, imageHeight, functionName = null, functionArgs = null,
+  tooltipText = null, imageID = null) {
   let imageHTML = '';
 
   // Add tooltip
@@ -368,19 +368,19 @@ function getImageHTML(
   if (functionName) {
     imageHTML += '<input type="image" src="' + imagePath + '"';
     imageHTML +=
-        ' onerror="this.onerror=null; this.src=\'' + ERROR_IMAGE + '\'"';
+      ' onerror="this.onerror=null; this.src=\'' + ERROR_IMAGE + '\'"';
     imageHTML += imageID ? ' id="' + imageID + '"' : '';
     imageHTML += ' height="' + imageHeight + '"';
     imageHTML += ' onclick="' + functionName +
-        (functionArgs ? '(\'' + functionArgs.replaceAll('\'', '\\\'') + '\')"' :
-                        '()"');
+      (functionArgs ? '(\'' + functionArgs.replaceAll('\'', '\\\'') + '\')"' :
+        '()"');
     imageHTML += '/>';
   }
   // Image (no button)
   else {
     imageHTML += '<img src="' + imagePath + '"';
     imageHTML +=
-        ' onerror="this.onerror=null; this.src=\'' + ERROR_IMAGE + '\'"';
+      ' onerror="this.onerror=null; this.src=\'' + ERROR_IMAGE + '\'"';
     imageHTML += imageID ? ' id="' + imageID + '"' : '';
     imageHTML += ' height="' + imageHeight + '">';
   }
@@ -521,9 +521,9 @@ function getBOPanelContent(overlayFlag, BOStepID) {
 
   // Configuration from within the BO panel
   const justifyFlex =
-      overlayOnRightSide ? 'justify_flex_end' : 'justify_flex_start';
+    overlayOnRightSide ? 'justify_flex_end' : 'justify_flex_start';
   htmlString +=
-      '<nobr><div class="bo_line bo_line_config ' + justifyFlex + '">';
+    '<nobr><div class="bo_line bo_line_config ' + justifyFlex + '">';
 
   // true to use the timer, false for manual selection
   const timingFlag = buildOrderTimer['use_timer'];
@@ -531,40 +531,40 @@ function getBOPanelContent(overlayFlag, BOStepID) {
   // Current step or time
   htmlString += '<div id="step_time_indication">';
   htmlString += timingFlag ? buildOrderTimer['last_time_label'] :
-                             'Step: ' + (BOStepID + 1) + '/' + stepCount;
+    'Step: ' + (BOStepID + 1) + '/' + stepCount;
   htmlString += '</div>';
 
   // Previous or next step
   const stepFunctionSuffix = overlayFlag ? 'Overlay' : 'Config';
 
   htmlString += getImageHTML(
-      commonPicturesFolder + 'action_button/previous.png', actionButtonHeight,
-      'previousStep' + stepFunctionSuffix, null,
-      timingFlag ? 'timer -1 sec' : 'previous BO step');
+    commonPicturesFolder + 'action_button/previous.png', actionButtonHeight,
+    'previousStep' + stepFunctionSuffix, null,
+    timingFlag ? 'timer -1 sec' : 'previous BO step');
   htmlString += getImageHTML(
-      commonPicturesFolder + 'action_button/next.png', actionButtonHeight,
-      'nextStep' + stepFunctionSuffix, null,
-      timingFlag ? 'timer +1 sec' : 'next BO step');
+    commonPicturesFolder + 'action_button/next.png', actionButtonHeight,
+    'nextStep' + stepFunctionSuffix, null,
+    timingFlag ? 'timer +1 sec' : 'next BO step');
 
   // Update timer
   if (timingFlag) {
     htmlString += getImageHTML(
-        commonPicturesFolder + 'action_button/' +
-            (buildOrderTimer['run_timer'] ? 'start_stop_active.png' :
-                                            'start_stop.png'),
-        actionButtonHeight, 'startStopBuildOrderTimer', null,
-        'start/stop the BO timer', 'start_stop_timer');
+      commonPicturesFolder + 'action_button/' +
+      (buildOrderTimer['run_timer'] ? 'start_stop_active.png' :
+        'start_stop.png'),
+      actionButtonHeight, 'startStopBuildOrderTimer', null,
+      'start/stop the BO timer', 'start_stop_timer');
     htmlString += getImageHTML(
-        commonPicturesFolder + 'action_button/timer_0.png', actionButtonHeight,
-        'resetBuildOrderTimer', null, 'reset the BO timer');
+      commonPicturesFolder + 'action_button/timer_0.png', actionButtonHeight,
+      'resetBuildOrderTimer', null, 'reset the BO timer');
   }
 
   // Switch between manual and timer
   if (overlayFlag && (buildOrderTimer['steps'].length > 0)) {
     htmlString += getImageHTML(
-        commonPicturesFolder + 'action_button/manual_timer_switch.png',
-        actionButtonHeight, 'switchBuildOrderTimerManual', null,
-        'switch BO mode between timer and manual');
+      commonPicturesFolder + 'action_button/manual_timer_switch.png',
+      actionButtonHeight, 'switchBuildOrderTimerManual', null,
+      'switch BO mode between timer and manual');
   }
   htmlString += '</div></nobr>';
 
@@ -584,7 +584,7 @@ function getBOPanelContent(overlayFlag, BOStepID) {
 
   if ('time' in resourceStep) {
     htmlString += getBOImageHTML(commonPicturesFolder + 'icon/time.png') +
-        resourceStep.time;
+      resourceStep.time;
   }
   htmlString += '</div></nobr>';
 
@@ -592,10 +592,10 @@ function getBOPanelContent(overlayFlag, BOStepID) {
   htmlString += '<hr style="width:100%;text-align:left;margin-left:0"></div>';
 
   // Loop on the steps for notes
-  selectedSteps.forEach(function(selectedStep, stepID) {
+  selectedSteps.forEach(function (selectedStep, stepID) {
     // Check if emphasis must be added on the corresponding note
     const emphasisFlag =
-        buildOrderTimer['run_timer'] && (selectedStepsIDs.includes(stepID));
+      buildOrderTimer['run_timer'] && (selectedStepsIDs.includes(stepID));
 
     // Notes of the current BO step
     const notes = selectedStep.notes;
@@ -620,7 +620,7 @@ function getBOPanelContent(overlayFlag, BOStepID) {
       // Add timing indication
       if (timingFlag && ('time' in selectedStep)) {
         htmlString += '<div class="bo_line_note_timing">' +
-            (noteID === 0 ? selectedStep.time : '') + '</div>';
+          (noteID === 0 ? selectedStep.time : '') + '</div>';
       }
 
       // Convert note line to HTML with text and images
@@ -666,7 +666,7 @@ function showHideItems() {
   const saveItems = ['save_bo_text', 'save_row'];
 
   const displayItems =
-      ['adapt_display_overlay', 'single_panel_page', 'diplay_overlay'];
+    ['adapt_display_overlay', 'single_panel_page', 'diplay_overlay'];
 
   // Items corresponding to flex boxes
   const flexItems = [
@@ -676,8 +676,8 @@ function showHideItems() {
 
   // Concatenation of all items
   const fullItems = libraryItems.concat(
-      websiteItems, designItems, designValidItems, designValidTimeItems,
-      saveItems, displayItems);
+    websiteItems, designItems, designValidItems, designValidTimeItems,
+    saveItems, displayItems);
 
   // Loop on all the items
   for (const itemName of fullItems) {
@@ -727,7 +727,7 @@ function showHideItems() {
 
     if (showItem) {  // Valid BO -> show items
       document.getElementById(itemName).style.display =
-          flexItems.includes(itemName) ? 'flex' : 'block';
+        flexItems.includes(itemName) ? 'flex' : 'block';
     } else {  // Invalid BO -> hide items
       document.getElementById(itemName).style.display = 'none';
     }
@@ -783,7 +783,7 @@ function updateDataBO() {
 
   // Display success/error message
   document.getElementById('bo_validity_message').textContent =
-      BOValidityMessage;
+    BOValidityMessage;
 
   if (!validBO) {  // BO is not valid
     updateInvalidDataBO();
@@ -815,7 +815,7 @@ function updateImagesSelection(subFolder) {
   // Maximum number of images per row
   let maxRowCount = MAX_ROW_SELECT_IMAGES;
   if ((gameName in SPECIAL_MAX_ROW_SELECT_IMAGES) &&
-      (subFolder in SPECIAL_MAX_ROW_SELECT_IMAGES[gameName])) {
+    (subFolder in SPECIAL_MAX_ROW_SELECT_IMAGES[gameName])) {
     maxRowCount = SPECIAL_MAX_ROW_SELECT_IMAGES[gameName][subFolder];
   }
 
@@ -823,7 +823,7 @@ function updateImagesSelection(subFolder) {
   if (subFolder === 'select faction') {
     for (const [key, value] of Object.entries(factionsList)) {
       console.assert(
-          value.length === 2, 'Faction list item should have a size of 2');
+        value.length === 2, 'Faction list item should have a size of 2');
 
       // Check if it is a valid image and get its path
       const imagePath = getImagePath(factionImagesFolder + '/' + value[1]);
@@ -832,7 +832,7 @@ function updateImagesSelection(subFolder) {
           imagesContent += '<div class="row">';  // start new row
         }
         imagesContent += getImageHTML(
-            imagePath, SELECT_IMAGE_HEIGHT, 'updateImageCopyClipboard', key);
+          imagePath, SELECT_IMAGE_HEIGHT, 'updateImageCopyClipboard', key);
 
         // Each row can have a maximum of images
         rowCount++;
@@ -856,8 +856,8 @@ function updateImagesSelection(subFolder) {
         }
         const imageWithSubFolder = '@' + subFolder + '/' + image + '@';
         imagesContent += getImageHTML(
-            imagePath, SELECT_IMAGE_HEIGHT, 'updateImageCopyClipboard',
-            imageWithSubFolder);
+          imagePath, SELECT_IMAGE_HEIGHT, 'updateImageCopyClipboard',
+          imageWithSubFolder);
 
         // Each row can have a maximum of images
         rowCount++;
@@ -887,15 +887,15 @@ function initBOFactionSelection() {
 
   // Filter on player faction, then on opponent faction
   for (const widgetID
-           of ['bo_faction_select_widget',
-               'bo_opponent_faction_select_widget']) {
+    of ['bo_faction_select_widget',
+      'bo_opponent_faction_select_widget']) {
     // Widget to select the faction (for BOs filtering)
     let factionSelectWidget = document.getElementById(widgetID);
     factionSelectWidget.innerHTML = null;  // Clear all options
 
     // Skip if no opponent faction filtering
     if ((widgetID === 'bo_opponent_faction_select_widget') &&
-        !FACTION_FIELD_NAMES[gameName]['opponent']) {
+      !FACTION_FIELD_NAMES[gameName]['opponent']) {
       factionSelectWidget.style.display = 'none';
     }
     // Display faction filtering
@@ -903,13 +903,13 @@ function initBOFactionSelection() {
       factionSelectWidget.style.display = 'block';
 
       console.assert(
-          Object.keys(factionsList).length >= 1,
-          'At least one faction expected.');
+        Object.keys(factionsList).length >= 1,
+        'At least one faction expected.');
       // Loop on all the factions
       for (const [factionName, shortAndImage] of Object.entries(factionsList)) {
         console.assert(
-            shortAndImage.length === 2,
-            '\'shortAndImage\' should have a size of 2');
+          shortAndImage.length === 2,
+          '\'shortAndImage\' should have a size of 2');
 
         let option = document.createElement('option');
         option.text = shortAndImage[0];
@@ -930,7 +930,7 @@ function updateFactionImageSelection() {
   // Filter on player faction, then on opponent faction
   for (let i = 0; i < 2; i++) {
     let factionImage = document.getElementById(
-        (i === 0) ? 'bo_faction_image' : 'bo_opponent_faction_image');
+      (i === 0) ? 'bo_faction_image' : 'bo_opponent_faction_image');
 
     // Skip if no opponent faction filtering
     if ((i === 1) && !FACTION_FIELD_NAMES[gameName]['opponent']) {
@@ -939,15 +939,15 @@ function updateFactionImageSelection() {
       factionImage.style.display = 'block';
 
       const widgetName = (i === 0) ? 'bo_faction_select_widget' :
-                                     'bo_opponent_faction_select_widget';
+        'bo_opponent_faction_select_widget';
       const shortAndImage =
-          factionsList[document.getElementById(widgetName).value];
+        factionsList[document.getElementById(widgetName).value];
       console.assert(
-          shortAndImage.length === 2,
-          '\'shortAndImage\' should have a size of 2');
+        shortAndImage.length === 2,
+        '\'shortAndImage\' should have a size of 2');
       factionImage.innerHTML = getImageHTML(
-          getImagePath(factionImagesFolder + '/' + shortAndImage[1]),
-          FACTION_ICON_HEIGHT);
+        getImagePath(factionImagesFolder + '/' + shortAndImage[1]),
+        FACTION_ICON_HEIGHT);
     }
   }
 }
@@ -987,21 +987,21 @@ function initImagesSelection() {
  */
 function updateMainConfigSelection() {
   const fromLibrary =
-      '<input type="radio" id="config_library" name="main_config_radios" value="library" checked>' +
-      '<label for="config_library" class="button">From library</label>';
+    '<input type="radio" id="config_library" name="main_config_radios" value="library" checked>' +
+    '<label for="config_library" class="button">From library</label>';
 
   const fromWebsite =
-      '<input type="radio" id="config_website" name="main_config_radios" value="website">' +
-      '<label for="config_website" class="button">From external website</label>';
+    '<input type="radio" id="config_website" name="main_config_radios" value="website">' +
+    '<label for="config_website" class="button">From external website</label>';
 
   const designYourOwn =
-      '<input type="radio" id="config_design" name="main_config_radios" value="design">' +
-      '<label for="config_design" class="button">Design your own</label>';
+    '<input type="radio" id="config_design" name="main_config_radios" value="design">' +
+    '<label for="config_design" class="button">Design your own</label>';
 
   // Add or not the website section (checking if there is at least one website).
   const fullContent = (gameName in EXTERNAL_BO_WEBSITES) ?
-      fromLibrary + fromWebsite + designYourOwn :
-      fromLibrary + designYourOwn;
+    fromLibrary + fromWebsite + designYourOwn :
+    fromLibrary + designYourOwn;
 
   document.getElementById('main_configuration').innerHTML = fullContent;
 
@@ -1012,7 +1012,7 @@ function updateMainConfigSelection() {
   // Updating when selecting another configuration
   let radios = document.querySelectorAll('input[name="main_config_radios"]');
   for (let i = 0; i < radios.length; i++) {
-    radios[i].addEventListener('change', function() {
+    radios[i].addEventListener('change', function () {
       mainConfiguration = this.value;
       showHideItems();
     });
@@ -1030,22 +1030,22 @@ function updateExternalBOWebsites() {
     // Add links to all websites
     for (const entry of EXTERNAL_BO_WEBSITES[gameName]) {
       console.assert(
-          entry.length === 3,
-          'All entries in \'EXTERNAL_BO_WEBSITES\' must have a size of 3.');
+        entry.length === 3,
+        'All entries in \'EXTERNAL_BO_WEBSITES\' must have a size of 3.');
       linksContent +=
-          '<form action="' + entry[1] + '" target="_blank" class="tooltip">';
+        '<form action="' + entry[1] + '" target="_blank" class="tooltip">';
       linksContent +=
-          '<input class="button" type="submit" value="' + entry[0] + '" />';
+        '<input class="button" type="submit" value="' + entry[0] + '" />';
       linksContent += '<span class="tooltiptext_right">';
       linksContent +=
-          '<div>External build order website providing build orders with RTS Overlay format.</div>';
+        '<div>External build order website providing build orders with RTS Overlay format.</div>';
       linksContent += '-----';
       linksContent += '<div>To import the requested build order:</div>';
       linksContent +=
-          '<div>1. Select the requested build order on ' + entry[0] + '.</div>';
+        '<div>1. Select the requested build order on ' + entry[0] + '.</div>';
       linksContent += '<div>2. ' + entry[2] + '</div>';
       linksContent +=
-          '<div>3. Paste the clipboard content on the right panel.</div>';
+        '<div>3. Paste the clipboard content on the right panel.</div>';
       linksContent += '</span>';
       linksContent += '</form>';
     }
@@ -1133,8 +1133,8 @@ function getDiplayOverlayTooltiptext() {
 function updateBOFromWidgets() {
   // Font size
   const fontSize = parseFloat(document.getElementById('bo_fontsize').value)
-                       .toFixed(1)
-                       .toString();
+    .toFixed(1)
+    .toString();
   document.getElementById('bo_fontsize_value').innerHTML = fontSize + ' (font)';
 
   let boPanelElement = document.getElementById('bo_panel');
@@ -1143,7 +1143,7 @@ function updateBOFromWidgets() {
   // Images size
   const imagesSize = parseInt(document.getElementById('bo_images_size').value);
   document.getElementById('bo_images_size_value').innerHTML =
-      imagesSize + ' (images)';
+    imagesSize + ' (images)';
 
   if (imagesSize !== imageHeightBO) {
     imageHeightBO = imagesSize;
@@ -1153,13 +1153,59 @@ function updateBOFromWidgets() {
 
   // Fixed top corner choice
   const newOverlayOnRightSide =
-      document.getElementById('left_right_side').checked;
+    document.getElementById('left_right_side').checked;
   if (newOverlayOnRightSide !== overlayOnRightSide) {
     overlayOnRightSide = newOverlayOnRightSide;
     document.getElementById('side_selection_text').innerHTML =
-        'overlay on the ' + (overlayOnRightSide ? 'right' : 'left');
+      'overlay on the ' + (overlayOnRightSide ? 'right' : 'left');
     updateBOPanel(false);
   }
+}
+
+/**
+ * Update the game and corresponding variables from its short name.
+ *
+ * @param {string} newGameName  Short name of the game (e.g. 'aoe2').
+ */
+function updateGameWithName(newGameName) {
+  let selectGame = document.getElementById('select_game');
+
+  // Loop on all the available games
+  for (let i = 0; i < selectGame.options.length; i++) {
+    if (selectGame.options[i].value === newGameName) {
+      selectGame.selectedIndex = i;
+      gameName = newGameName;
+      gameFullName = selectGame.options[i].text;
+
+      updateGame(); // Update the other variables
+      return;
+    }
+  }
+  console.log('Warning: no game found with the name \'' + newGameName + '\'.');
+}
+
+/**
+ * Update the variables after selecting a game.
+ * The variables 'gameName' and 'gameFullName' must already be defined.
+ */
+function updateGame() {
+  imagesGame = getImagesGame();
+  factionsList = getFactions();
+  factionImagesFolder = getFactionImagesFolder();
+
+  updateMainConfigSelection();
+  updateExternalBOWebsites();
+  updateRTSOverlayInfo();
+  initImagesSelection();
+  initBOFactionSelection();
+  readLibrary();
+  updateLibrarySearch();
+
+  resetDataBOMsg();
+  document.getElementById('bo_design').value = getWelcomeMessage();
+  updateSalamanderIcon();
+
+  showHideItems();
 }
 
 /**
@@ -1198,7 +1244,7 @@ function initConfigWindow() {
 
   // Update the hotkeys tooltip for 'Diplay overlay'
   document.getElementById('diplay_overlay_tooltiptext').innerHTML =
-      getDiplayOverlayTooltiptext();
+    getDiplayOverlayTooltiptext();
 
   // Initialize the BO panel
   resetDataBOMsg();
@@ -1208,87 +1254,71 @@ function initConfigWindow() {
   // Set default sliders values
   document.getElementById('bo_fontsize').value = DEFAULT_BO_PANEL_FONTSIZE;
   document.getElementById('bo_images_size').value =
-      DEFAULT_BO_PANEL_IMAGES_SIZE;
+    DEFAULT_BO_PANEL_IMAGES_SIZE;
   document.getElementById('left_right_side').checked =
-      DEFAULT_OVERLAY_ON_RIGHT_SIDE;
+    DEFAULT_OVERLAY_ON_RIGHT_SIDE;
   updateBOFromWidgets();
 
   // Show or hide elements
   showHideItems();
 
   // Updating the variables when changing the game
-  document.getElementById('select_game').addEventListener('input', function() {
+  document.getElementById('select_game').addEventListener('input', function () {
     const selectGame = document.getElementById('select_game');
     gameName = selectGame.value;
     gameFullName = selectGame.options[selectGame.selectedIndex].text;
 
-    imagesGame = getImagesGame();
-    factionsList = getFactions();
-    factionImagesFolder = getFactionImagesFolder();
-
-    updateMainConfigSelection();
-    updateExternalBOWebsites();
-    updateRTSOverlayInfo();
-    initImagesSelection();
-    initBOFactionSelection();
-    readLibrary();
-    updateLibrarySearch();
-
-    resetDataBOMsg();
-    document.getElementById('bo_design').value = getWelcomeMessage();
-    updateSalamanderIcon();
-
-    showHideItems();
+    updateGame();
   });
 
   // Panel is automatically updated when the BO design panel is changed
-  document.getElementById('bo_design').addEventListener('input', function() {
+  document.getElementById('bo_design').addEventListener('input', function () {
     updateDataBO();
     updateBOPanel(false);
   });
 
   // Update the selection images each time a new category is selected
   document.getElementById('image_class_selection')
-      .addEventListener('input', function() {
-        updateImagesSelection(
-            document.getElementById('image_class_selection').value);
-      });
+    .addEventListener('input', function () {
+      updateImagesSelection(
+        document.getElementById('image_class_selection').value);
+    });
 
   // Update BO elements when any slider is moving
-  document.getElementById('bo_fontsize').addEventListener('input', function() {
+  document.getElementById('bo_fontsize').addEventListener('input', function () {
     updateBOFromWidgets();
   });
 
   document.getElementById('bo_images_size')
-      .addEventListener('input', function() {
-        updateBOFromWidgets();
-      });
+    .addEventListener('input', function () {
+      updateBOFromWidgets();
+    });
 
   // Update BO side selection when updating the corresponding toggle
   document.getElementById('left_right_side')
-      .addEventListener('input', function() {
-        updateBOFromWidgets();
-      });
+    .addEventListener('input', function () {
+      updateBOFromWidgets();
+    });
 
   // Update the library search for each new input or faction selection
   document.getElementById('bo_faction_text')
-      .addEventListener('input', function() {
-        updateLibrarySearch();
-      });
+    .addEventListener('input', function () {
+      updateLibrarySearch();
+    });
 
   document.getElementById('bo_faction_select_widget')
-      .addEventListener('input', function() {
-        updateFactionImageSelection();
-        updateLibraryValidKeys();
-        updateLibrarySearch();
-      });
+    .addEventListener('input', function () {
+      updateFactionImageSelection();
+      updateLibraryValidKeys();
+      updateLibrarySearch();
+    });
 
   document.getElementById('bo_opponent_faction_select_widget')
-      .addEventListener('input', function() {
-        updateFactionImageSelection();
-        updateLibraryValidKeys();
-        updateLibrarySearch();
-      });
+    .addEventListener('input', function () {
+      updateFactionImageSelection();
+      updateLibraryValidKeys();
+      updateLibrarySearch();
+    });
 }
 
 /**
@@ -1296,7 +1326,7 @@ function initConfigWindow() {
  */
 function updateTitle() {
   document.getElementById('rts_overlay_title').innerHTML =
-      getImageHTML('assets/common/title/rts_overlay.png', TITLE_IMAGE_HEIGHT);
+    getImageHTML('assets/common/title/rts_overlay.png', TITLE_IMAGE_HEIGHT);
 }
 
 /**
@@ -1304,10 +1334,10 @@ function updateTitle() {
  */
 function updateRTSOverlayInfo() {
   let content = '<div>' +
-      getImageHTML('assets/common/icon/info.png', INFO_IMAGE_HEIGHT) + '</div>';
+    getImageHTML('assets/common/icon/info.png', INFO_IMAGE_HEIGHT) + '</div>';
   content +=
-      '<span id="tooltip_rts_overlay_info" class="tooltiptext_left"><div>' +
-      getInstructions() + '</div></span>';
+    '<span id="tooltip_rts_overlay_info" class="tooltiptext_left"><div>' +
+    getInstructions() + '</div></span>';
 
   document.getElementById('rts_overlay_info').innerHTML = content;
 }
@@ -1320,8 +1350,8 @@ function updateSalamanderIcon() {
   document.getElementById('bo_panel_sliders').style.display = 'none';
   document.getElementById('left_right_toggle').style.display = 'none';
   document.getElementById('salamander').innerHTML = getImageHTML(
-      'assets/common/icon/salamander_sword_shield.png',
-      SALAMANDER_IMAGE_HEIGHT);
+    'assets/common/icon/salamander_sword_shield.png',
+    SALAMANDER_IMAGE_HEIGHT);
 }
 
 /**
@@ -1350,7 +1380,7 @@ function updateBOPanel(overlayFlag) {
 
   // Update BO content
   document.getElementById('bo_panel').innerHTML =
-      getBOPanelContent(overlayFlag, stepID);
+    getBOPanelContent(overlayFlag, stepID);
 
   // Updates for the overlay BO panel
   if (overlayFlag) {
@@ -1368,7 +1398,7 @@ function updateBOPanel(overlayFlag) {
  */
 function initOverlayWindow() {
   // Using hotkeys to interact with the overlay
-  document.addEventListener('keydown', function(event) {
+  document.addEventListener('keydown', function (event) {
     const code = event.code;
     if (code !== '') {
       switch (code) {
@@ -1417,9 +1447,9 @@ function getImagesCommon() {
   // This is obtained using the 'python/utilities/list_images.py' script.
   let imagesDict = {
     'action_button':
-        'feather.png#gears.png#leave.png#load.png#manual_timer_switch.png#next.png#pause.png#previous.png#save.png#start_stop.png#start_stop_active.png#timer_0.png#to_beginning.png#to_end.png',
+      'feather.png#gears.png#leave.png#load.png#manual_timer_switch.png#next.png#pause.png#previous.png#save.png#start_stop.png#start_stop_active.png#timer_0.png#to_beginning.png#to_end.png',
     'icon':
-        'house.png#mouse.png#question_mark.png#salamander_sword_shield.png#time.png'
+      'house.png#mouse.png#question_mark.png#salamander_sword_shield.png#time.png'
   };
 
   // Split each string (e.g. 'image_0#image_1#image_2') in a list of images.
@@ -1450,12 +1480,12 @@ function checkBuildOrderKeyValues(buildOrder, keyCondition = null) {
       const dataCheck = buildOrder[key];
       // Any build order data value is valid
       if (['any', 'Any', 'Generic'].includes(dataCheck) ||
-          ['any', 'Any'].includes(target)) {
+        ['any', 'Any'].includes(target)) {
         continue;
       }
       const isArray = Array.isArray(dataCheck);
       if ((isArray && (!dataCheck.includes(target))) ||
-          (!isArray && (target !== dataCheck))) {
+        (!isArray && (target !== dataCheck))) {
         return false;  // at least one key condition not met
       }
     }
@@ -1481,7 +1511,7 @@ function checkBuildOrderKeyValues(buildOrder, keyCondition = null) {
  * @returns Updated note (potentially with illustration).
  */
 function convertTXTNoteToIllustrated(
-    note, convertDict, toLower = false, maxSize = -1, ignoreInDict = null) {
+  note, convertDict, toLower = false, maxSize = -1, ignoreInDict = null) {
   const noteSplit = note.split(' ');    // note split based on spaces
   const splitCount = noteSplit.length;  // number of elements in the split
 
@@ -1501,24 +1531,24 @@ function convertTXTNoteToIllustrated(
     // number of gather sets that can be made
     const setCount = splitCount - gatherCount + 1;
     console.assert(
-        1 <= setCount && setCount <= splitCount, 'setCount value not correct.');
+      1 <= setCount && setCount <= splitCount, 'setCount value not correct.');
 
     // ID of the first element
     for (let firstID = 0; firstID < setCount; firstID++) {
       console.assert(
-          0 <= firstID && firstID < splitCount, 'firstID value not correct.');
+        0 <= firstID && firstID < splitCount, 'firstID value not correct.');
       let checkNote = noteSplit[firstID];
 
       for (let nextElemID = firstID + 1; nextElemID < firstID + gatherCount;
-           nextElemID++) {  // gather the next elements
+        nextElemID++) {  // gather the next elements
         console.assert(
-            1 <= nextElemID && nextElemID < splitCount,
-            'nextElemID not correct.');
+          1 <= nextElemID && nextElemID < splitCount,
+          'nextElemID not correct.');
         checkNote += ' ' + noteSplit[nextElemID];
       }
 
       let updatedCheckNote =
-          checkNote.slice(0);  // update based on requests (slice for copy)
+        checkNote.slice(0);  // update based on requests (slice for copy)
 
       for (const ignoreElem of ignoreInDict) {  // ignore parts in dictionary
         updatedCheckNote = updatedCheckNote.replaceAll(ignoreElem, '');
@@ -1548,7 +1578,7 @@ function convertTXTNoteToIllustrated(
 
           // Get back ignored parts (after dictionary replace)
           for (let characterID = checkNoteLen - 1; characterID >= 0;
-               characterID--) {
+            characterID--) {
             if (ignoreInDict.includes(checkNote[characterID])) {
               ignoreAfter += checkNote[characterID];
             } else {
@@ -1565,8 +1595,8 @@ function convertTXTNoteToIllustrated(
         let beforeNote = '';
         for (let beforeID = 0; beforeID < firstID; beforeID++) {
           console.assert(
-              0 <= beforeID && beforeID < splitCount,
-              'beforeID value not correct.');
+            0 <= beforeID && beforeID < splitCount,
+            'beforeID value not correct.');
           beforeNote += ' ' + noteSplit[beforeID];
         }
         beforeNote = beforeNote.replaceAll(/^\s+/gm, '');  // lstrip in Python
@@ -1574,10 +1604,10 @@ function convertTXTNoteToIllustrated(
         // Gather note parts after the found sub-note
         let afterNote = '';
         for (let afterID = firstID + gatherCount; afterID < splitCount;
-             afterID++) {
+          afterID++) {
           console.assert(
-              0 <= afterID && afterID < splitCount,
-              'afterID value not correct.');
+            0 <= afterID && afterID < splitCount,
+            'afterID value not correct.');
           afterNote += ' ' + noteSplit[afterID];
         }
         afterNote = afterNote.replaceAll(/^\s+/gm, '');  // lstrip in Python
@@ -1586,19 +1616,19 @@ function convertTXTNoteToIllustrated(
         let finalNote = '';
         if (beforeNote !== '') {
           finalNote +=
-              convertTXTNoteToIllustrated(
-                  beforeNote, convertDict, toLower, maxSize, ignoreInDict) +
-              ' ';
+            convertTXTNoteToIllustrated(
+              beforeNote, convertDict, toLower, maxSize, ignoreInDict) +
+            ' ';
         }
 
         finalNote += ignoreBefore + '@' + convertDict[updatedCheckNote] + '@' +
-            ignoreAfter;
+          ignoreAfter;
 
         if (afterNote !== '') {
           finalNote +=
-              ' ' +
-              convertTXTNoteToIllustrated(
-                  afterNote, convertDict, toLower, maxSize, ignoreInDict);
+            ' ' +
+            convertTXTNoteToIllustrated(
+              afterNote, convertDict, toLower, maxSize, ignoreInDict);
         }
 
         return finalNote;
@@ -1624,7 +1654,7 @@ function buildOrderTimeToStr(timeSec) {
   }
 
   return Math.floor(timeSec / 60).toString() + ':' +
-      ('0' + (timeSec % 60).toString()).slice(-2);
+    ('0' + (timeSec % 60).toString()).slice(-2);
 }
 
 /**
@@ -1767,7 +1797,7 @@ function getBuildOrderTimerStepIDs(steps, currentTimeSec, startingFlag = true) {
   for (const currentStepID of stepRange) {
     const step = steps[currentStepID];
     if ((startingFlag && (currentTimeSec >= step['time_sec'])) ||
-        (!startingFlag && (currentTimeSec <= step['time_sec']))) {
+      (!startingFlag && (currentTimeSec <= step['time_sec']))) {
       if (step['time_sec'] !== lastTimeSec) {
         selectedIDs = [currentStepID];
         lastTimeSec = step['time_sec'];
@@ -1798,7 +1828,7 @@ function getBuildOrderTimerStepsDisplay(steps, stepIDs) {
   console.assert(stepIDs.length > 0, 'stepIDs must be > 0.');
   for (const stepID of stepIDs) {
     console.assert(
-        0 <= stepID && stepID < steps.length, 'Invalid value for stepID.');
+      0 <= stepID && stepID < steps.length, 'Invalid value for stepID.');
   }
   stepIDs.sort();  // safety (should already be the case)
 
@@ -1825,8 +1855,8 @@ function getBuildOrderTimerStepsDisplay(steps, stepIDs) {
   const finalID = Math.min(steps.length, stepIDs.at(-1) + 2);
 
   console.assert(
-      0 <= initID && initID < finalID && finalID <= steps.length,
-      'Invalid values for initID and/or finalID.');
+    0 <= initID && initID < finalID && finalID <= steps.length,
+    'Invalid values for initID and/or finalID.');
 
   const outSteps = steps.slice(initID, finalID);
   let outStepIDs = [];
@@ -1838,8 +1868,8 @@ function getBuildOrderTimerStepsDisplay(steps, stepIDs) {
   }
 
   console.assert(
-      (outStepIDs.length > 0) && (outSteps.length > 0),
-      'Wrong size for the selected steps and/or IDs');
+    (outStepIDs.length > 0) && (outSteps.length > 0),
+    'Wrong size for the selected steps and/or IDs');
   return [outStepIDs, outSteps];
 }
 
@@ -1859,7 +1889,7 @@ function switchBuildOrderTimerManual() {
 
     // Select current step
     if (!buildOrderTimer['use_timer'] &&
-        (buildOrderTimer['steps_ids'].length > 0)) {
+      (buildOrderTimer['steps_ids'].length > 0)) {
       stepID = buildOrderTimer['steps_ids'][0];
     }
 
@@ -1876,8 +1906,8 @@ function updateBuildOrderStartStopTimerIcon() {
   let elem = document.getElementById('start_stop_timer');
   if (elem) {
     elem.src = 'assets/common/action_button/' +
-        (buildOrderTimer['run_timer'] ? 'start_stop_active.png' :
-                                        'start_stop.png');
+      (buildOrderTimer['run_timer'] ? 'start_stop_active.png' :
+        'start_stop.png');
   }
 }
 
@@ -1893,7 +1923,7 @@ function startStopBuildOrderTimer(invertRun = true, runValue = true) {
     const newRunState = invertRun ? (!buildOrderTimer['run_timer']) : runValue;
 
     if (newRunState !==
-        buildOrderTimer['run_timer']) {  // only update if change
+      buildOrderTimer['run_timer']) {  // only update if change
       buildOrderTimer['run_timer'] = newRunState;
 
       // Time
@@ -1935,7 +1965,7 @@ function getBuildOrderSelectedStepsAndIDs(BOStepID) {
   if (buildOrderTimer['use_timer'] && buildOrderTimer['steps'].length > 0) {
     // Get steps to display
     return getBuildOrderTimerStepsDisplay(
-        buildOrderTimer['steps'], buildOrderTimer['steps_ids']);
+      buildOrderTimer['steps'], buildOrderTimer['steps_ids']);
   } else {
     const buildOrderData = dataBO['build_order'];
 
@@ -1945,8 +1975,8 @@ function getBuildOrderSelectedStepsAndIDs(BOStepID) {
     const selectedSteps = [buildOrderData[BOStepID]];
     console.assert(selectedSteps[0] !== null, 'Selected steps are not valid');
     console.assert(
-        (selectedSteps.length > 0) && (selectedStepsIDs.length > 0),
-        'Wrong size for the selected steps and/or IDs');
+      (selectedSteps.length > 0) && (selectedStepsIDs.length > 0),
+      'Wrong size for the selected steps and/or IDs');
     return [selectedStepsIDs, selectedSteps];
   }
 }
@@ -1993,16 +2023,16 @@ function checkValidFaction(BONameStr, factionName, requested, anyValid = true) {
     if (Array.isArray(factionData)) {  // List of factions
       if (factionData.length === 0) {
         return invalidMsg(
-            BONameStr + 'Valid "' + factionName + '" list is empty.');
+          BONameStr + 'Valid "' + factionName + '" list is empty.');
       }
 
       for (const faction of factionData) {  // Loop on the provided factions
         const anyFlag = ['any', 'Any'].includes(faction);
         if (!(!anyFlag && (faction in factionsList)) &&
-            !(anyFlag && anyValid)) {
+          !(anyFlag && anyValid)) {
           return invalidMsg(
-              BONameStr + 'Unknown ' + factionName + ' "' + faction +
-              '" (check spelling).');
+            BONameStr + 'Unknown ' + factionName + ' "' + faction +
+            '" (check spelling).');
         }
       }
     }
@@ -2010,10 +2040,10 @@ function checkValidFaction(BONameStr, factionName, requested, anyValid = true) {
     else {
       const anyFlag = ['any', 'Any'].includes(factionData);
       if (!(!anyFlag && (factionData in factionsList)) &&
-          !(anyFlag && anyValid)) {
+        !(anyFlag && anyValid)) {
         return invalidMsg(
-            BONameStr + 'Unknown ' + factionName + ' "' + factionData +
-            '" (check spelling).');
+          BONameStr + 'Unknown ' + factionName + ' "' + factionData +
+          '" (check spelling).');
       }
     }
   }
@@ -2043,7 +2073,7 @@ class FieldDefinition {
   constructor(name, type, requested, parentName = null, validRange = null) {
     // Check input types
     if (typeof name !== 'string' || typeof type !== 'string' ||
-        (parentName && typeof parentName !== 'string')) {
+      (parentName && typeof parentName !== 'string')) {
       throw 'FieldDefinition expected strings for \'name\', \'type\' and \'parentName\'.';
     }
 
@@ -2106,7 +2136,7 @@ class FieldDefinition {
   checkRange(value) {
     // Check only needed for integer values with defined range
     if (this.type !== 'integer' || !Number.isInteger(value) ||
-        !this.validRange) {
+      !this.validRange) {
       return true;
     }
 
@@ -2125,13 +2155,13 @@ class FieldDefinition {
   check(value) {
     if (!this.checkType(value)) {
       return invalidMsg(
-          'Wrong value (' + value + '), expected ' + this.type + ' type.');
+        'Wrong value (' + value + '), expected ' + this.type + ' type.');
     }
 
     if (!this.checkRange(value)) {
       return invalidMsg(
-          'Wrong value (' + value + '), must be in [' + this.validRange[0] +
-          ' ; ' + this.validRange[1] + '] range.');
+        'Wrong value (' + value + '), must be in [' + this.validRange[0] +
+        ' ; ' + this.validRange[1] + '] range.');
     }
 
     return validMsg();
@@ -2172,7 +2202,7 @@ function checkValidSteps(BONameStr, fields) {
   for (const [stepID, step] of enumerate(buildOrderData)) {
     // Prefix before error message
     const prefixMsg = BONameStr + 'Step ' + (stepID + 1).toString() + '/' +
-        buildOrderData.length + ' | ';
+      buildOrderData.length + ' | ';
 
     // Loop on all the step fields
     for (const field of fields) {
@@ -2187,21 +2217,21 @@ function checkValidSteps(BONameStr, fields) {
             const res = field.check(step[field.parentName][field.name]);
             if (!res[0]) {
               return invalidMsg(
-                  prefixMsg + '"' + field.parentName + '/' + field.name +
-                  '" | ' + res[1]);
+                prefixMsg + '"' + field.parentName + '/' + field.name +
+                '" | ' + res[1]);
             }
           }
           // Child field is missing
           else if (field.requested) {
             return invalidMsg(
-                prefixMsg + 'Missing field: "' + field.parentName + '/' +
-                field.name + '".');
+              prefixMsg + 'Missing field: "' + field.parentName + '/' +
+              field.name + '".');
           }
         }
         // Parent field missing
         else if (field.requested) {
           return invalidMsg(
-              prefixMsg + 'Missing field: "' + field.parentName + '".');
+            prefixMsg + 'Missing field: "' + field.parentName + '".');
         }
       }
       // Not present in a parent
@@ -2232,7 +2262,7 @@ function evaluateTime() {
 
     // Update text editing space
     document.getElementById('bo_design').value =
-        JSON.stringify(dataBO, null, 4);
+      JSON.stringify(dataBO, null, 4);
 
     // Update BO and panel
     updateDataBO();
@@ -2277,23 +2307,23 @@ function timerBuildOrderCall() {
       elapsedTime *= buildOrderTimer['timer_speed_factor'];
     }
     buildOrderTimer['time_sec'] =
-        buildOrderTimer['time_sec_init'] + elapsedTime;
+      buildOrderTimer['time_sec_init'] + elapsedTime;
     buildOrderTimer['time_int'] = Math.floor(buildOrderTimer['time_sec']);
 
     // Time was updated (or no valid note IDs)
     if ((buildOrderTimer['last_time_int'] !== buildOrderTimer['time_int']) ||
-        (buildOrderTimer['last_steps_ids'].length === 0)) {
+      (buildOrderTimer['last_steps_ids'].length === 0)) {
       buildOrderTimer['last_time_int'] = buildOrderTimer['time_int'];
 
       // Compute current note IDs
       buildOrderTimer['steps_ids'] = getBuildOrderTimerStepIDs(
-          buildOrderTimer['steps'], buildOrderTimer['time_int'],
-          buildOrderTimer['step_starting_flag']);
+        buildOrderTimer['steps'], buildOrderTimer['time_int'],
+        buildOrderTimer['step_starting_flag']);
 
       // Note IDs were updated
       if (buildOrderTimer['last_steps_ids'] !== buildOrderTimer['steps_ids']) {
         buildOrderTimer['last_steps_ids'] =
-            buildOrderTimer['steps_ids'].slice();  // slice for copy
+          buildOrderTimer['steps_ids'].slice();  // slice for copy
         updateBOPanel(true);
       }
     }
@@ -2306,7 +2336,7 @@ function timerBuildOrderCall() {
 function formatBuildOrder() {
   if (dataBO) {
     document.getElementById('bo_design').value =
-        JSON.stringify(dataBO, null, 4);
+      JSON.stringify(dataBO, null, 4);
     updateDataBO();
     updateBOPanel(false);
   }
@@ -2354,7 +2384,7 @@ function BODesignDropHandler(ev) {
 
   // Use file content for 'bo_design' text area
   let reader = new FileReader();
-  reader.onload = function(e) {
+  reader.onload = function (e) {
     bo_design.value = e.target.result;
     updateDataBO();
     updateBOPanel(false);
@@ -2375,7 +2405,7 @@ function saveBOToFile(data = null) {
   }
 
   // Create a file with the BO content
-  const file = new Blob([JSON.stringify(data, null, 4)], {type: 'text/plain'});
+  const file = new Blob([JSON.stringify(data, null, 4)], { type: 'text/plain' });
 
   // Add file content in an object URL with <a> tag
   const link = document.createElement('a');
@@ -2410,8 +2440,8 @@ function deleteSelectedBO() {
   }
 
   const text = 'Are you sure you want to delete the build order \'' +
-      selectedBOFromLibrary + '\' (' + gameFullName +
-      ') from your local storage?\nThis cannot be undone.';
+    selectedBOFromLibrary + '\' (' + gameFullName +
+    ') from your local storage?\nThis cannot be undone.';
   if (confirm(text)) {
     localStorage.removeItem(keyName);
     readLibrary();
@@ -2425,8 +2455,8 @@ function deleteSelectedBO() {
  */
 function deleteAllBOs() {
   const text = 'Are you sure you want to delete ALL BUILD ORDERS (from ' +
-      gameFullName + ') from your local storage?' +
-      '\nThis cannot be undone.';
+    gameFullName + ') from your local storage?' +
+    '\nThis cannot be undone.';
 
   if (confirm(text)) {
     const gamePrefix = gameName + '|';
@@ -2473,14 +2503,14 @@ function addToLocalStorage() {
 
     if (localStorage.getItem(keyName)) {
       const text = 'There is already a build order with name \'' +
-          dataBO['name'] + '\' for ' + gameFullName +
-          '.\nDo you want to replace it with your new build order?';
+        dataBO['name'] + '\' for ' + gameFullName +
+        '.\nDo you want to replace it with your new build order?';
       if (!confirm(text)) {
         return;
       }
     } else {
       const text = 'Do you want to save your build order with name \'' +
-          dataBO['name'] + '\' for ' + gameFullName + '?';
+        dataBO['name'] + '\' for ' + gameFullName + '?';
       if (!confirm(text)) {
         return;
       }
@@ -2490,8 +2520,8 @@ function addToLocalStorage() {
     readLibrary();
     updateLibrarySearch();
     alert(
-        'Build order saved with key name \'' + keyName +
-        '\' in local storage.');
+      'Build order saved with key name \'' + keyName +
+      '\' in local storage.');
 
   } else {
     alert('Build order is not valid. It cannot be saved.');
@@ -2529,8 +2559,8 @@ function computeLevenshtein(strA, strB) {
         matrix[i][j] = matrix[i - 1][j - 1];
       } else {
         matrix[i][j] = Math.min(
-            matrix[i - 1][j] + 1, matrix[i][j - 1] + 1,
-            matrix[i - 1][j - 1] + 1);
+          matrix[i - 1][j] + 1, matrix[i][j - 1] + 1,
+          matrix[i - 1][j - 1] + 1);
       }
     }
   }
@@ -2553,7 +2583,7 @@ function computeSameSizeLevenshtein(strSmall, strLarge) {
   const lenSmall = strSmall.length;
   const lenLarge = strLarge.length;
   console.assert(
-      lenSmall <= lenLarge, '\'strSmall\' must be smaller than \'strLarge\'.');
+    lenSmall <= lenLarge, '\'strSmall\' must be smaller than \'strLarge\'.');
 
   // Normal Levenshtein computation is same size
   if (lenSmall === lenLarge) {
@@ -2571,7 +2601,7 @@ function computeSameSizeLevenshtein(strSmall, strLarge) {
 
   for (let i = 1; i <= maxId; i++) {
     const currentScore =
-        computeLevenshtein(strSmall, strLarge.slice(i, i + lenSmall));
+      computeLevenshtein(strSmall, strLarge.slice(i, i + lenSmall));
     if (currentScore === 1) {  // Cannot be smaller than 1 if not included
       return 1;
     } else if (currentScore < minScore) {
@@ -2655,11 +2685,11 @@ function getKeyCondition() {
   let keyCondition = {};
   if (playerFactionName) {
     keyCondition[playerFactionName] =
-        document.getElementById('bo_faction_select_widget').value;
+      document.getElementById('bo_faction_select_widget').value;
   }
   if (opponentFactionName) {
     keyCondition[opponentFactionName] =
-        document.getElementById('bo_opponent_faction_select_widget').value;
+      document.getElementById('bo_opponent_faction_select_widget').value;
   }
 
   return keyCondition;
@@ -2735,7 +2765,7 @@ function compareLibraryFaction(keyCondition, itemA, itemB) {
 function clearSearchResultSelect() {
   let elements = document.getElementsByClassName('search_key_line');
 
-  Array.prototype.forEach.call(elements, function(el) {
+  Array.prototype.forEach.call(elements, function (el) {
     document.getElementById(el.id).classList.remove('search_key_select');
   });
 }
@@ -2749,7 +2779,7 @@ function mouseOverSearchResult(id) {
   clearSearchResultSelect();
 
   document.getElementById('search_key_line_' + id)
-      .classList.add('search_key_select');
+    .classList.add('search_key_select');
 }
 
 /**
@@ -2768,9 +2798,9 @@ function mouseClickSearchResult(key) {
 
   // Update build order search lines
   let boSearchText =
-      '<div " class="search_key_line">Selected build order:</div>';
+    '<div " class="search_key_line">Selected build order:</div>';
   boSearchText +=
-      '<div " class="search_key_line search_key_select">' + key + '</div>';
+    '<div " class="search_key_line search_key_select">' + key + '</div>';
 
   document.getElementById('bo_faction_text').value = '';
   document.getElementById('bo_search_results').innerHTML = boSearchText;
@@ -2786,7 +2816,7 @@ function mouseClickSearchResult(key) {
 function updateLibrarySearch() {
   // Value to search in lower case
   const searchStr =
-      document.getElementById('bo_faction_text').value.toLowerCase();
+    document.getElementById('bo_faction_text').value.toLowerCase();
 
   // Selected BO is null if the search field is not empty
   if (searchStr !== '') {
@@ -2798,23 +2828,23 @@ function updateLibrarySearch() {
   // Library is empty
   if (Object.keys(library).length === 0) {
     boSearchText +=
-        '<div>No build order in library for <i>' + gameFullName + '</i>.</div>';
+      '<div>No build order in library for <i>' + gameFullName + '</i>.</div>';
     if (gameName in EXTERNAL_BO_WEBSITES) {
       boSearchText +=
-          '<div>Download one <b>from an external website</b> or <b>design your own</b>.</div>';
+        '<div>Download one <b>from an external website</b> or <b>design your own</b>.</div>';
     } else {
       boSearchText +=
-          '<div><b>Design your own</b> build order in the corresponding panel.</div>';
+        '<div><b>Design your own</b> build order in the corresponding panel.</div>';
     }
   }
   // No build order for the currently selected faction condition
   else if (libraryValidKeys.length === 0) {
     boSearchText += '<div>No build order in your library for faction <b>' +
-        document.getElementById('bo_faction_select_widget').value + '</b>';
+      document.getElementById('bo_faction_select_widget').value + '</b>';
     if (FACTION_FIELD_NAMES[gameName]['opponent']) {
       boSearchText += ' with opponent <b>' +
-          document.getElementById('bo_opponent_faction_select_widget').value +
-          '</b>';
+        document.getElementById('bo_opponent_faction_select_widget').value +
+        '</b>';
     }
     boSearchText += '.</div>';
   }
@@ -2823,26 +2853,26 @@ function updateLibrarySearch() {
     // Nothing added in the search field
     if (searchStr.length === 0) {
       const factionName =
-          document.getElementById('bo_faction_select_widget').value;
+        document.getElementById('bo_faction_select_widget').value;
       boSearchText += '<div>Select the player faction above (' +
-          factionsList[factionName][0] + ': <b>' + factionName + '</b>)';
+        factionsList[factionName][0] + ': <b>' + factionName + '</b>)';
 
       if (FACTION_FIELD_NAMES[gameName]['opponent']) {
         const opponentFactionName =
-            document.getElementById('bo_opponent_faction_select_widget').value;
+          document.getElementById('bo_opponent_faction_select_widget').value;
         boSearchText += ' and opponent faction (' +
-            factionsList[opponentFactionName][0] + ': <b>' +
-            opponentFactionName + '</b>)';
+          factionsList[opponentFactionName][0] + ': <b>' +
+          opponentFactionName + '</b>)';
       }
       boSearchText += '.</div>';
 
       boSearchText +=
-          '<div>Then, add <b>keywords</b> in the text field to search any build order from your library.</div>';
+        '<div>Then, add <b>keywords</b> in the text field to search any build order from your library.</div>';
       boSearchText +=
-          '<div>Alternatively, use <b>a single space</b> to select the first ' +
-          MAX_SEARCH_RESULTS + ' build orders.</div>';
+        '<div>Alternatively, use <b>a single space</b> to select the first ' +
+        MAX_SEARCH_RESULTS + ' build orders.</div>';
       boSearchText +=
-          '<div>Finally, click on the requested build order from the list (will appear here).</div>';
+        '<div>Finally, click on the requested build order from the list (will appear here).</div>';
     }
     // Look for pattern in search field
     else {
@@ -2858,7 +2888,7 @@ function updateLibrarySearch() {
         for (const key of libraryValidKeys) {
           const keyLowerCase = key.toLowerCase();
           const score = computeSameSizeLevenshteinThreshold(
-              LEVENSHTEIN_RATIO_THRESHOLD, searchStr, keyLowerCase);
+            LEVENSHTEIN_RATIO_THRESHOLD, searchStr, keyLowerCase);
           if (score >= 0) {  // Valid match
             librayKeyScores[key] = score;
             librarySortedKeys.push(key);
@@ -2866,14 +2896,14 @@ function updateLibrarySearch() {
         }
         // Sort the keys based on the metrics above
         librarySortedKeys.sort(
-            (a, b) => compareLibraryKeys(librayKeyScores, a, b));
+          (a, b) => compareLibraryKeys(librayKeyScores, a, b));
 
         // Only keep the first results
         librarySortedKeys = librarySortedKeys.slice(0, MAX_SEARCH_RESULTS);
 
         // Sort by faction requirement
         librarySortedKeys.sort(
-            (a, b) => compareLibraryFaction(keyCondition, a, b));
+          (a, b) => compareLibraryFaction(keyCondition, a, b));
       }
       // Take the first results, sorting only by faction requirement
       else {
@@ -2882,7 +2912,7 @@ function updateLibrarySearch() {
 
         // Sort by faction requirement
         librarySortedKeys.sort(
-            (a, b) => compareLibraryFaction(keyCondition, a, b));
+          (a, b) => compareLibraryFaction(keyCondition, a, b));
 
         // Only keep the first results
         librarySortedKeys = librarySortedKeys.slice(0, MAX_SEARCH_RESULTS);
@@ -2893,10 +2923,10 @@ function updateLibrarySearch() {
       let keyID = 0;
       for (const key of librarySortedKeys) {
         boSearchText += '<div id="search_key_line_' + keyID +
-            '" class="search_key_line" onmouseover="mouseOverSearchResult(' +
-            keyID +
-            ')" onmouseleave="clearSearchResultSelect()" onclick="mouseClickSearchResult(\'' +
-            key.replaceAll('\'', '\\\'') + '\')">' + key + '</div>';
+          '" class="search_key_line" onmouseover="mouseOverSearchResult(' +
+          keyID +
+          ')" onmouseleave="clearSearchResultSelect()" onclick="mouseClickSearchResult(\'' +
+          key.replaceAll('\'', '\\\'') + '\')">' + key + '</div>';
         keyID++;
       }
     }
@@ -2940,17 +2970,17 @@ class SinglePanelColumn {
    *                                     null for default.
    */
   constructor(
-      field, image = null, italic = false, bold = false, hideIfAbsent = false,
-      displayIfPositive = false, backgroundColor = null, textAlign = null) {
+    field, image = null, italic = false, bold = false, hideIfAbsent = false,
+    displayIfPositive = false, backgroundColor = null, textAlign = null) {
     // Check input types
     if (typeof field !== 'string' || (image && typeof image !== 'string') ||
-        (textAlign && typeof textAlign !== 'string')) {
+      (textAlign && typeof textAlign !== 'string')) {
       throw 'SinglePanelColumn expected strings for \'field\', \'image\' and \'textAlign\'.';
     }
 
     if (typeof italic !== 'boolean' || typeof bold !== 'boolean' ||
-        typeof hideIfAbsent !== 'boolean' ||
-        typeof displayIfPositive !== 'boolean') {
+      typeof hideIfAbsent !== 'boolean' ||
+      typeof displayIfPositive !== 'boolean') {
       throw 'SinglePanelColumn expected boolean for \'italic\',  \'bold\',  \'hideIfAbsent\' and  \'displayIfPositive\'.';
     }
 
@@ -2984,7 +3014,7 @@ class SinglePanelColumn {
  *                                    and 'after', null if no section.
  */
 function openSinglePanelPageFromDescription(
-    columnsDescription, sectionsHeader = null) {
+  columnsDescription, sectionsHeader = null) {
   // Check if valid BO data
   if (!checkValidBO()) {
     return;
@@ -3033,8 +3063,8 @@ function openSinglePanelPageFromDescription(
             }
           } else {
             console.log(
-                'Warning: Exepcted integer for \'' + field +
-                '\', but received \'' + fieldValue + '\'.');
+              'Warning: Exepcted integer for \'' + field +
+              '\', but received \'' + fieldValue + '\'.');
           }
         } else {
           displayColumns[index] = true;
@@ -3061,14 +3091,14 @@ function openSinglePanelPageFromDescription(
 
   // Title
   htmlContent +=
-      indentSpace(1) + '<title>RTS Overlay - ' + dataBO['name'] + '</title>\n';
+    indentSpace(1) + '<title>RTS Overlay - ' + dataBO['name'] + '</title>\n';
 
   // Style
   htmlContent += indentSpace(1) + '<style>\n';
 
   htmlContent += indentSpace(2) + 'body {\n';
   htmlContent +=
-      indentSpace(3) + 'font-family: Arial, Helvetica, sans-serif;\n';
+    indentSpace(3) + 'font-family: Arial, Helvetica, sans-serif;\n';
   htmlContent += indentSpace(3) + 'background-color: rgb(220, 220, 220);\n';
   htmlContent += indentSpace(2) + '}\n\n';
 
@@ -3142,7 +3172,7 @@ function openSinglePanelPageFromDescription(
   // Style from column description
   for (const [index, column] of updatedColumnsDescription.entries()) {
     if (column.italic || column.bold || column.backgroundColor ||
-        column.textAlign) {
+      column.textAlign) {
       htmlContent += indentSpace(2) + '.column-' + index.toString() + ' {\n';
 
       if (column.italic) {
@@ -3154,14 +3184,14 @@ function openSinglePanelPageFromDescription(
       if (column.backgroundColor) {
         color = column.backgroundColor;
         console.assert(
-            color.length == 3, 'Background color length should be of size 3.');
+          color.length == 3, 'Background color length should be of size 3.');
         htmlContent += indentSpace(3) + 'background-color: rgb(' +
-            color[0].toString() + ', ' + color[1].toString() + ', ' +
-            color[2].toString() + ');\n';
+          color[0].toString() + ', ' + color[1].toString() + ', ' +
+          color[2].toString() + ');\n';
       }
       if (column.textAlign) {
         htmlContent +=
-            indentSpace(3) + 'text-align: ' + column.textAlign + ';\n';
+          indentSpace(3) + 'text-align: ' + column.textAlign + ';\n';
       }
       htmlContent += indentSpace(2) + '}\n\n';
     }
@@ -3180,7 +3210,7 @@ function openSinglePanelPageFromDescription(
   for (const column of updatedColumnsDescription) {
     if (column.image) {
       htmlContent +=
-          indentSpace(3) + '<td>' + getBOImageHTML(column.image) + '</td>\n';
+        indentSpace(3) + '<td>' + getBOImageHTML(column.image) + '</td>\n';
     } else {
       indentSpace(3) + '<td></td>\n';
     }
@@ -3198,8 +3228,8 @@ function openSinglePanelPageFromDescription(
     if (sectionsHeader) {
       // Key to check for section header
       console.assert(
-          sectionsHeader.key in currentStep,
-          'Current step is missing \'' + sectionsHeader.key + '\'.');
+        sectionsHeader.key in currentStep,
+        'Current step is missing \'' + sectionsHeader.key + '\'.');
       const keyValue = currentStep[sectionsHeader.key];
 
       // Activate if first line or seen in the previous line
@@ -3207,7 +3237,7 @@ function openSinglePanelPageFromDescription(
         if (sectionsHeader.after && (keyValue in sectionsHeader.after)) {
           htmlContent += indentSpace(2) + '<tr class="border_top">\n';
           htmlContent += indentSpace(3) + '<td class="full_line" colspan=8>' +
-              sectionsHeader.after[keyValue] + '</td>\n';
+            sectionsHeader.after[keyValue] + '</td>\n';
           htmlContent += indentSpace(2) + '</tr>\n';
         }
         previousHeaderFlag = false;
@@ -3217,7 +3247,7 @@ function openSinglePanelPageFromDescription(
         if (sectionsHeader.before && (keyValue in sectionsHeader.before)) {
           htmlContent += indentSpace(2) + '<tr class="border_top">\n';
           htmlContent += indentSpace(3) + '<td class="full_line" colspan=8>' +
-              sectionsHeader.before[keyValue] + '</td>\n';
+            sectionsHeader.before[keyValue] + '</td>\n';
           htmlContent += indentSpace(2) + '</tr>\n';
         }
         previousHeaderFlag = true;
@@ -3258,14 +3288,14 @@ function openSinglePanelPageFromDescription(
               }
             } else {
               console.log(
-                  'Warning: Exepcted integer for \'' + field +
-                  '\', but received \'' + fieldValue + '\'.');
+                'Warning: Exepcted integer for \'' + field +
+                '\', but received \'' + fieldValue + '\'.');
             }
           }
 
           // Display field value
           htmlContent += indentSpace(3) + '<td class="column-' +
-              index.toString() + '">' + fieldValue + '</td>\n';
+            index.toString() + '">' + fieldValue + '</td>\n';
         }
       }
       // Only add notes for the next lines (i.e. no column content).
@@ -3273,14 +3303,14 @@ function openSinglePanelPageFromDescription(
         htmlContent += indentSpace(2) + '<tr>\n';
         for (let index = 0; index < updatedColumnsDescription.length; index++) {
           htmlContent += indentSpace(3) + '<td class="column-' +
-              index.toString() + '"></td>\n';
+            index.toString() + '"></td>\n';
         }
       }
 
       // Add the current note line
       htmlContent += indentSpace(3) + '<td class="note">\n' + indentSpace(4) +
-          '<div>' + noteToTextImages(note) + '</div>\n' + indentSpace(3) +
-          '</td>\n';
+        '<div>' + noteToTextImages(note) + '</div>\n' + indentSpace(3) +
+        '</td>\n';
       htmlContent += indentSpace(2) + '</tr>\n';
     }
   }
@@ -3289,12 +3319,12 @@ function openSinglePanelPageFromDescription(
 
   // Copy HTML for export
   const htmlContentCopy =
-      JSON.parse(JSON.stringify(htmlContent)) + '</body>\n\n</html>';
+    JSON.parse(JSON.stringify(htmlContent)) + '</body>\n\n</html>';
 
   // Name for file export
   const exportName = (Object.keys(dataBO).includes('name')) ?
-      dataBO.name.replaceAll(/\s+/g, '_') :
-      'rts_overlay';
+    dataBO.name.replaceAll(/\s+/g, '_') :
+    'rts_overlay';
 
   // Buttons to export HTML and build order
   htmlContent += '\n<button id="export_html">Export HTML</button>\n';
@@ -3303,35 +3333,35 @@ function openSinglePanelPageFromDescription(
   htmlContent += indentSpace(1) + '<script>\n';
 
   htmlContent += indentSpace(2) +
-      'const dataHTML = ' + JSON.stringify(htmlContentCopy) + ';\n\n';
+    'const dataHTML = ' + JSON.stringify(htmlContentCopy) + ';\n\n';
   htmlContent +=
-      indentSpace(2) + 'const dataBO = ' + JSON.stringify(dataBO) + ';\n\n';
+    indentSpace(2) + 'const dataBO = ' + JSON.stringify(dataBO) + ';\n\n';
 
   // Export HTML
   htmlContent += indentSpace(2) +
-      'document.getElementById(\'export_html\').addEventListener(\'click\', function() {\n';
+    'document.getElementById(\'export_html\').addEventListener(\'click\', function() {\n';
   htmlContent += indentSpace(3) +
-      'const fileHTML = new Blob([dataHTML], {type: \'text/plain\'});\n';
+    'const fileHTML = new Blob([dataHTML], {type: \'text/plain\'});\n';
   htmlContent +=
-      indentSpace(3) + 'const link = document.createElement(\'a\');\n';
+    indentSpace(3) + 'const link = document.createElement(\'a\');\n';
   htmlContent +=
-      indentSpace(3) + 'link.href = URL.createObjectURL(fileHTML);\n';
+    indentSpace(3) + 'link.href = URL.createObjectURL(fileHTML);\n';
   htmlContent +=
-      indentSpace(3) + 'link.download = \'' + exportName + '.html\';\n';
+    indentSpace(3) + 'link.download = \'' + exportName + '.html\';\n';
   htmlContent += indentSpace(3) + 'link.click();\n';
   htmlContent += indentSpace(3) + 'URL.revokeObjectURL(link.href);\n';
   htmlContent += indentSpace(2) + '});\n\n';
 
   // Export BO
   htmlContent += indentSpace(2) +
-      'document.getElementById(\'export_bo\').addEventListener(\'click\', function() {\n';
+    'document.getElementById(\'export_bo\').addEventListener(\'click\', function() {\n';
   htmlContent += indentSpace(3) +
-      'const fileBO = new Blob([JSON.stringify(dataBO, null, 4)], {type: \'text/plain\'});\n';
+    'const fileBO = new Blob([JSON.stringify(dataBO, null, 4)], {type: \'text/plain\'});\n';
   htmlContent +=
-      indentSpace(3) + 'const link = document.createElement(\'a\');\n';
+    indentSpace(3) + 'const link = document.createElement(\'a\');\n';
   htmlContent += indentSpace(3) + 'link.href = URL.createObjectURL(fileBO);\n';
   htmlContent +=
-      indentSpace(3) + 'link.download = \'' + exportName + '.json\';\n';
+    indentSpace(3) + 'link.download = \'' + exportName + '.json\';\n';
   htmlContent += indentSpace(3) + 'link.click();\n';
   htmlContent += indentSpace(3) + 'URL.revokeObjectURL(link.href);\n';
   htmlContent += indentSpace(2) + '});\n\n';
@@ -3364,7 +3394,7 @@ function displayOverlay() {
 
   // Build order initialized for step 0
   const bodyContent = '<div id="bo_panel">' +
-      getBOPanelContent(true, validBO ? 0 : -1) + '</div>';
+    getBOPanelContent(true, validBO ? 0 : -1) + '</div>';
 
   // HTML content
   let htmlContent = '<!DOCTYPE html><html lang="en">';
@@ -3376,14 +3406,14 @@ function displayOverlay() {
   htmlContent += '\nconst SLEEP_TIME = ' + SLEEP_TIME + ';';
   htmlContent += '\nconst INTERVAL_CALL_TIME = ' + INTERVAL_CALL_TIME + ';';
   htmlContent +=
-      '\nconst SIZE_UPDATE_THRESHOLD = ' + SIZE_UPDATE_THRESHOLD + ';';
+    '\nconst SIZE_UPDATE_THRESHOLD = ' + SIZE_UPDATE_THRESHOLD + ';';
   htmlContent += '\nconst OVERLAY_KEYBOARD_SHORTCUTS = ' +
-      JSON.stringify(OVERLAY_KEYBOARD_SHORTCUTS) + ';';
+    JSON.stringify(OVERLAY_KEYBOARD_SHORTCUTS) + ';';
   htmlContent += '\nconst ERROR_IMAGE = "' + ERROR_IMAGE + '";';
 
   htmlContent += '\nconst gameName = \'' + gameName + '\';';
   htmlContent +=
-      '\nconst dataBO = ' + (validBO ? JSON.stringify(dataBO) : 'null') + ';';
+    '\nconst dataBO = ' + (validBO ? JSON.stringify(dataBO) : 'null') + ';';
   htmlContent += '\nconst stepCount = ' + (validBO ? stepCount : -1) + ';';
   htmlContent += '\nlet stepID = ' + (validBO ? 0 : -1) + ';';
   htmlContent += '\nconst imagesGame = ' + JSON.stringify(imagesGame) + ';';
@@ -3392,19 +3422,19 @@ function displayOverlay() {
 
   const fontsizeSlider = document.getElementById('bo_fontsize');
   htmlContent += '\nconst bo_panel_font_size = \'' +
-      fontsizeSlider.value.toString(1) + 'em\';';
+    fontsizeSlider.value.toString(1) + 'em\';';
 
   // Adapt timer variables for overlay
   let timerOverlay = Object.assign({}, buildOrderTimer);  // copy the object
   timerOverlay['step_starting_flag'] =
-      TIMER_STEP_STARTING_FLAG.includes(gameName);
+    TIMER_STEP_STARTING_FLAG.includes(gameName);
   timerOverlay['absolute_time_init'] = getCurrentTime();
   timerOverlay['steps_ids'] = [0];
   if (gameName in TIMER_SPEED_FACTOR) {
     timerOverlay['timer_speed_factor'] = TIMER_SPEED_FACTOR[gameName];
   }
   htmlContent +=
-      '\nlet buildOrderTimer = ' + JSON.stringify(timerOverlay) + ';';
+    '\nlet buildOrderTimer = ' + JSON.stringify(timerOverlay) + ';';
 
   htmlContent += '\ninitOverlayWindow();';
 
@@ -3462,9 +3492,9 @@ function displayOverlay() {
   htmlContent += '\n</script>';
 
   htmlContent += '\n<head><link rel="stylesheet" href="layout.css">' +
-      headContent + '</head>';
+    headContent + '</head>';
   htmlContent +=
-      '\n<body id=\"body_overlay\">' + bodyContent + '</body></html>';
+    '\n<body id=\"body_overlay\">' + bodyContent + '</body></html>';
 
   // Update overlay HTML content
   overlayWindow.document.write(htmlContent);
@@ -3555,7 +3585,7 @@ function contentArrayToDiv(content) {
  * @returns Requested instructions.
  */
 function getArrayInstructions(
-    evaluateTimeFlag, selectFactionLines = null, externalBOLines = null) {
+  evaluateTimeFlag, selectFactionLines = null, externalBOLines = null) {
   let result = [
     'Replace the text in the panel below by any build order in correct JSON format, then click on \'Open full page\' or \'Display overlay\'',
     '(appearing on the left side of the screen when the build order is valid). You will need an Always On Top application',
@@ -3572,7 +3602,7 @@ function getArrayInstructions(
   const buttonsLines = [
     '',
     'You can' + (externalBOLines ? ' also' : '') +
-        ' manually write your build order as JSON format, using the following buttons',
+    ' manually write your build order as JSON format, using the following buttons',
     'from the <b>Design your own</b> section (some buttons only appear when the build order is valid):',
     '&nbsp &nbsp - \'Reset build order\' : Reset the build order to a minimal template (adapt the initial fields).',
     '&nbsp &nbsp - \'Add step\' : Add a step to the build order.',
@@ -3863,18 +3893,18 @@ function getResourceLineAoE2(currentStep) {
   const resources = currentStep.resources;
 
   htmlString +=
-      getBOImageValue(resourceFolder + 'Aoe2de_wood.png', resources, 'wood');
+    getBOImageValue(resourceFolder + 'Aoe2de_wood.png', resources, 'wood');
   htmlString +=
-      getBOImageValue(resourceFolder + 'Aoe2de_food.png', resources, 'food');
+    getBOImageValue(resourceFolder + 'Aoe2de_food.png', resources, 'food');
   htmlString +=
-      getBOImageValue(resourceFolder + 'Aoe2de_gold.png', resources, 'gold');
+    getBOImageValue(resourceFolder + 'Aoe2de_gold.png', resources, 'gold');
   htmlString +=
-      getBOImageValue(resourceFolder + 'Aoe2de_stone.png', resources, 'stone');
+    getBOImageValue(resourceFolder + 'Aoe2de_stone.png', resources, 'stone');
   htmlString += getBOImageValue(
-      resourceFolder + 'Aoe2de_hammer.png', resources, 'builder', true);
+    resourceFolder + 'Aoe2de_hammer.png', resources, 'builder', true);
   htmlString += getBOImageValue(
-      resourceFolder + 'MaleVillDE_alpha.png', currentStep, 'villager_count',
-      true);
+    resourceFolder + 'MaleVillDE_alpha.png', currentStep, 'villager_count',
+    true);
 
   // Age image
   const ageImage = {
@@ -3886,7 +3916,7 @@ function getResourceLineAoE2(currentStep) {
 
   if (currentStep.age in ageImage) {
     htmlString +=
-        getBOImageHTML(gamePicturesFolder + 'age/' + ageImage[currentStep.age]);
+      getBOImageHTML(gamePicturesFolder + 'age/' + ageImage[currentStep.age]);
   }
 
   return htmlString;
@@ -3950,15 +3980,15 @@ function getBOStepAoE2(builOrderData) {
       'villager_count': ('villager_count' in data) ? data['villager_count'] : 0,
       'age': ('age' in data) ? data['age'] : 1,
       'resources': ('resources' in data) ?
-          data['resources'] :
-          {'wood': 0, 'food': 0, 'gold': 0, 'stone': 0},
+        data['resources'] :
+        { 'wood': 0, 'food': 0, 'gold': 0, 'stone': 0 },
       'notes': ['Note 1', 'Note 2']
     };
   } else {
     return {
       'villager_count': 0,
       'age': 1,
-      'resources': {'wood': 0, 'food': 0, 'gold': 0, 'stone': 0},
+      'resources': { 'wood': 0, 'food': 0, 'gold': 0, 'stone': 0 },
       'notes': ['Note 1', 'Note 2']
     };
   }
@@ -4056,7 +4086,7 @@ function getLoomTimeAoE2(civilizationFlags, currentAge) {
  * @returns Requested research time [sec].
  */
 function getWheelbarrowHandcartTimeAoE2(
-    civilizationFlags, currentAge, wheelbarrowFlag) {
+  civilizationFlags, currentAge, wheelbarrowFlag) {
   console.assert(1 <= currentAge && currentAge <= 4, 'Age expected in [1;4].');
   const genericTime = wheelbarrowFlag ? 75.0 : 55.0;
   if (civilizationFlags['Persians']) {
@@ -4082,7 +4112,7 @@ function getWheelbarrowHandcartTimeAoE2(
  * @returns Requested research time [sec].
  */
 function getTownWatchPatrolTimeAoE2(
-    civilizationFlags, currentAge, townWatchFlag) {
+  civilizationFlags, currentAge, townWatchFlag) {
   console.assert(1 <= currentAge && currentAge <= 4, 'Age expected in [1;4].');
   const genericTime = townWatchFlag ? 25.0 : 40.0;
   if (civilizationFlags['Persians']) {
@@ -4106,7 +4136,7 @@ function getTownWatchPatrolTimeAoE2(
  * @returns Requested research time [sec].
  */
 function getTownCenterResearchTimeAoE2(
-    technologyName, civilizationFlags, currentAge) {
+  technologyName, civilizationFlags, currentAge) {
   if (technologyName === 'loom') {
     return getLoomTimeAoE2(civilizationFlags, currentAge);
   } else if (technologyName === 'wheelbarrow') {
@@ -4119,7 +4149,7 @@ function getTownCenterResearchTimeAoE2(
     return getTownWatchPatrolTimeAoE2(civilizationFlags, currentAge, false);
   } else {
     console.log(
-        'Warning: unknown TC technology name \'' + technologyName + '\'.');
+      'Warning: unknown TC technology name \'' + technologyName + '\'.');
     return 0.0;
   }
 }
@@ -4155,20 +4185,20 @@ function evaluateBOTimingAoE2(timeOffset) {
 
   // TC technologies to research
   TCTechnologies = {
-    'loom': {'researched': false, 'image': 'town_center/LoomDE.png'},
+    'loom': { 'researched': false, 'image': 'town_center/LoomDE.png' },
     'wheelbarrow':
-        {'researched': false, 'image': 'town_center/WheelbarrowDE.png'},
-    'handcart': {'researched': false, 'image': 'town_center/HandcartDE.png'},
-    'town_watch': {'researched': false, 'image': 'town_center/TownWatchDE.png'},
+      { 'researched': false, 'image': 'town_center/WheelbarrowDE.png' },
+    'handcart': { 'researched': false, 'image': 'town_center/HandcartDE.png' },
+    'town_watch': { 'researched': false, 'image': 'town_center/TownWatchDE.png' },
     'town_patrol':
-        {'researched': false, 'image': 'town_center/TownPatrolDE.png'}
+      { 'researched': false, 'image': 'town_center/TownPatrolDE.png' }
   };
 
   let lastTimeSec = timeOffset;  // time of the last step
 
   if (!('build_order' in dataBO)) {
     console.log(
-        'Warning: the "build_order" field is missing from data when evaluating the timing.');
+      'Warning: the "build_order" field is missing from data when evaluating the timing.');
     return;
   }
 
@@ -4186,8 +4216,8 @@ function evaluateBOTimingAoE2(timeOffset) {
     if (villagerCount < 0) {
       const resources = currentStep['resources'];
       villagerCount = Math.max(0, resources['wood']) +
-          Math.max(0, resources['food']) + Math.max(0, resources['gold']) +
-          Math.max(0, resources['stone']);
+        Math.max(0, resources['food']) + Math.max(0, resources['gold']) +
+        Math.max(0, resources['stone']);
       if ('builder' in resources) {
         villagerCount += Math.max(0, resources['builder']);
       }
@@ -4198,12 +4228,12 @@ function evaluateBOTimingAoE2(timeOffset) {
     lastVillagerCount = villagerCount;
 
     stepTotalTime += updateVillagerCount *
-        getVillagerTimeAoE2(civilizationFlags, currentAge);
+      getVillagerTimeAoE2(civilizationFlags, currentAge);
 
     // Next age
     const nextAge = (1 <= currentStep['age'] && currentStep['age'] <= 4) ?
-        currentStep['age'] :
-        currentAge;
+      currentStep['age'] :
+      currentAge;
     if (nextAge === currentAge + 1)  // researching next age up
     {
       stepTotalTime += getResearchAgeUpTimeAoE2(civilizationFlags, currentAge);
@@ -4219,11 +4249,11 @@ function evaluateBOTimingAoE2(timeOffset) {
     // Check for TC technologies in notes
     for (const note of currentStep['notes']) {
       for (const [technologyName, technologyData] of Object.entries(
-               TCTechnologies)) {
+        TCTechnologies)) {
         if ((!technologyData['researched']) &&
-            (note.includes('@' + technologyData['image'] + '@'))) {
+          (note.includes('@' + technologyData['image'] + '@'))) {
           stepTotalTime += getTownCenterResearchTimeAoE2(
-              technologyName, civilizationFlags, currentAge);
+            technologyName, civilizationFlags, currentAge);
           technologyData['researched'] = true;
         }
       }
@@ -4240,7 +4270,7 @@ function evaluateBOTimingAoE2(timeOffset) {
     // Special case for last step (add 1 sec to avoid displaying both at the
     // same time)
     if ((currentStepID === stepCount - 1) && (stepCount >= 2) &&
-        (currentStep['time'] === buildOrderData[currentStepID - 1]['time'])) {
+      (currentStep['time'] === buildOrderData[currentStepID - 1]['time'])) {
       currentStep['time'] = buildOrderTimeToStr(Math.round(lastTimeSec + 1.0));
     }
   }
@@ -4254,51 +4284,51 @@ function evaluateBOTimingAoE2(timeOffset) {
 function getImagesAoE2() {
   // This is obtained using the 'python/utilities/list_images.py' script.
   const
-      imagesDict =
-          {
-            'age':
-                'AgeUnknown.png#CastleAgeIconDE.png#CastleAgeIconDE_alpha.png#DarkAgeIconDE.png#DarkAgeIconDE_alpha.png#FeudalAgeIconDE.png#FeudalAgeIconDE_alpha.png#ImperialAgeIconDE.png#ImperialAgeIconDE_alpha.png',
-            'animal':
-                'AoE2DE_ingame_goose_icon.png#AoE2DE_ingame_ibex_icon.png#AoE2_DE_box_turtles_icon.png#AoE2_DE_dolphin_icon.png#AoE2_DE_dorado_icon.png#AoE2_DE_marlin_icon.png#AoE2_DE_perch_icon.png#AoE2_DE_salmon_icon.png#AoE2_DE_shore_fish_icon.png#AoE2_DE_snapper_icon.png#AoE2_DE_tuna_icon.png#Boar_aoe2DE.png#CowDE.png#Deer_aoe2DE.png#Elephant_aoe2DE.png#Goat_aoe2DE.png#Llama_aoe2DE.png#Ostrich_icon_aoe2de.png#Pig_aoe2DE.png#Rhinoceros_aoe2DE.png#Sheep_aoe2DE.png#Turkey_aoe2DE.png#Yak_aoe2DE.png#Zebra_aoe2DE.png',
-            'archery_range':
-                'Aoe2de_DOI_elephant_archer_icon.png#ArbalestDE.png#Arbalester_aoe2DE.png#Archery_range_aoe2DE.png#Archer_aoe2DE.png#Cavalryarcher_aoe2DE.png#Crossbowman_aoe2DE.png#ElephantArcherIcon-DE.png#Elite_skirmisher_aoe2DE.png#Hand_cannoneer_aoe2DE.png#Heavycavalryarcher_aoe2de.png#ImperialSkirmisherUpgDE.png#ParthianTacticsDE.png#Skirmisher_aoe2DE.png#ThumbRingDE.png#Heavy-cavalry-archer-resear.jpg',
-            'barracks':
-                'Aoe2-infantry-2-pikeman.png#ArsonDE.png#Barracks_aoe2DE.png#ChampionUpgDE.png#Champion_aoe2DE.png#Eaglescout_aoe2DE.png#EagleWarriorUpgDE.png#Eaglewarrior_aoe2DE.png#EliteEagleWarriorUpgDE.png#EliteEaglewarrior_aoe2DE.png#GambesonsDE.png#HalberdierDE.png#Halberdier_aoe2DE.png#LongSwordmanUpgDE.png#Longswordsman_aoe2DE.png#ManAtArmsUpgDE.png#Manatarms_aoe2DE.png#MilitiaDE.png#PikemanUpDE.png#Spearman_aoe2DE.png#SquiresDE.png#Suplliesicon.png#TwoHandedSwordsmanUpgDE.png#Twohanded_aoe2DE.png',
-            'blacksmith':
-                'Blacksmith_aoe2de.png#BlastFurnaceDE.png#BodkinArrowDE.png#BracerDE.png#ChainBardingDE.png#ChainMailArmorDE.png#FletchingDE.png#Forging_aoe2de.png#IronCastingDE.png#LeatherArcherArmorDE.png#PaddedArcherArmorDE.png#PlateBardingArmorDE.png#PlateMailArmorDE.png#RingArcherArmorDE.png#ScaleBardingArmorDE.png#ScaleMailArmorDE.png',
-            'castle':
-                'CastleAgeUnique.png#Castle_aoe2DE.png#ConscriptionDE.png#HoardingsDE.png#Petard_aoe2DE.png#SapperDE.png#SpiesDE.png#Trebuchet_aoe2DE.png#Unique-tech-imperial.jpg',
-            'civilization':
-                'CivIcon-Armenians.png#CivIcon-Aztecs.png#CivIcon-Bengalis.png#CivIcon-Berbers.png#CivIcon-Bohemians.png#CivIcon-Britons.png#CivIcon-Bulgarians.png#CivIcon-Burgundians.png#CivIcon-Burmese.png#CivIcon-Byzantines.png#CivIcon-Celts.png#CivIcon-Chinese.png#CivIcon-Cumans.png#CivIcon-Dravidians.png#CivIcon-Ethiopians.png#CivIcon-Franks.png#CivIcon-Georgians.png#CivIcon-Goths.png#CivIcon-Gurjaras.png#CivIcon-Hindustanis.png#CivIcon-Huns.png#CivIcon-Incas.png#CivIcon-Indians.png#CivIcon-Italians.png#CivIcon-Japanese.png#CivIcon-Khmer.png#CivIcon-Koreans.png#CivIcon-Lithuanians.png#CivIcon-Magyars.png#CivIcon-Malay.png#CivIcon-Malians.png#CivIcon-Mayans.png#CivIcon-Mongols.png#CivIcon-Persians.png#CivIcon-Poles.png#CivIcon-Portuguese.png#CivIcon-Romans.png#CivIcon-Saracens.png#CivIcon-Sicilians.png#CivIcon-Slavs.png#CivIcon-Spanish.png#CivIcon-Tatars.png#CivIcon-Teutons.png#CivIcon-Turks.png#CivIcon-Vietnamese.png#CivIcon-Vikings.png#question_mark.png#question_mark_black.png',
-            'defensive_structures':
-                'Bombard_tower_aoe2DE.png#Donjon_aoe2DE.png#FortifiedWallDE.png#Gate_aoe2de.png#Krepost_aoe2de.png#Outpost_aoe2de.png#Palisade_gate_aoe2DE.png#Palisade_wall_aoe2de.png#Stone_wall_aoe2de.png#Tower_aoe2de.png',
-            'dock':
-                'Cannon_galleon_aoe2DE.png#CareeningDE.png#Demoraft_aoe2DE.png#Demoship_aoe2DE.png#Dock_aoe2de.png#DryDockDE.png#Elite-cannon-galleon-resear.png#Elite_cannon_galleon_aoe2de.png#Fastfireship_aoe2DE.png#Fireship_aoe2DE.png#Fire_galley_aoe2DE.png#FishingShipDE.png#Fish_trap_aoe2DE.png#GalleonUpgDE.png#Galleon_aoe2DE.png#Galley_aoe2DE.png#GillnetsDE.png#Heavydemoship_aoe2de.png#ShipwrightDE.png#Trade_cog_aoe2DE.png#Transportship_aoe2DE.png#WarGalleyDE.png#War_galley_aoe2DE.png',
-            'lumber_camp':
-                'BowSawDE.png#DoubleBitAxe_aoe2DE.png#Lumber_camp_aoe2de.png#TwoManSawDE.png',
-            'market':
-                'BankingDE.png#CaravanDE.png#CoinageDE.png#GuildsDE.png#Market_aoe2DE.png#Tradecart_aoe2DE.png',
-            'mill':
-                'Aoe2-icon--folwark.png#CropRotationDE.png#FarmDE.png#HeavyPlowDE.png#HorseCollarDE.png#Mill_aoe2de.png',
-            'mining_camp':
-                'GoldMiningDE.png#GoldShaftMiningDE.png#Mining_camp_aoe2de.png#StoneMiningDE.png#StoneShaftMiningDE.png',
-            'monastery':
-                'AtonementDE.png#BlockPrintingDE.png#FaithDE.png#FervorDE.png#FortifiedChurch.png#HerbalDE.png#HeresyDE.png#IlluminationDE.png#MonasteryAoe2DE.png#Monk_aoe2DE.png#RedemptionDE.png#SanctityDE.png#TheocracyDE.png',
-            'other':
-                'Ao2de_caravanserai_icon.png#Feitoria_aoe2DE.png#House_aoe2DE.png#MuleCart.png#Wonder_aoe2DE.png',
-            'resource':
-                'Aoe2de_food.png#Aoe2de_gold.png#Aoe2de_hammer.png#Aoe2de_stone.png#Aoe2de_wood.png#BerryBushDE.png#MaleVillDE_alpha.png#tree.png#MaleVillDE.jpg',
-            'siege_workshop':
-                'AoE2DE_Armored_Elephant_icon.png#AoE2DE_Siege_Elephant_icon.png#Battering_ram_aoe2DE.png#Bombard_cannon_aoe2DE.png#CappedRamDE.png#Capped_ram_aoe2DE.png#HeavyScorpionDE.png#Heavyscorpion_aoe2DE.png#Mangonel_aoe2DE.png#OnagerDE.png#Onager_aoe2DE.png#Scorpion_aoe2DE.png#SiegeOnagerDE.png#Siegetower_aoe2DE.png#Siege_onager_aoe2DE.png#Siege_ram_aoe2DE.png#Siege_workshop_aoe2DE.png#Siege-ram-research.jpg',
-            'stable':
-                'Aoe2de_camel_scout.png#Aoe2_heavycamelriderDE.png#Battle_elephant_aoe2DE.png#BloodlinesDE.png#Camelrider_aoe2DE.png#Cavalier_aoe2DE.png#EliteBattleElephantUpg.png#Elitesteppelancericon.png#EliteSteppeLancerUpgDE.png#Elite_battle_elephant_aoe2DE.png#HeavyCamelUpgDE.png#HusbandryDE.png#Hussar_aoe2DE.png#Hussar_upgrade_aoe2de.png#Knight_aoe2DE.png#Lightcavalry_aoe2DE.png#Paladin_aoe2DE.png#Scoutcavalry_aoe2DE.png#Stable_aoe2DE.png#Steppelancericon.png#Winged-hussar_upgrade.png#Cavalier-research.jpg#Light-cavalry-research.jpg#Paladin-research.jpg',
-            'town_center':
-                'HandcartDE.png#LoomDE.png#Towncenter_aoe2DE.png#TownPatrolDE.png#TownWatchDE.png#WheelbarrowDE.png',
-            'unique_unit':
-                'Aoe2-icon--houfnice.png#Aoe2-icon--obuch.png#Aoe2-icon-coustillier.png#Aoe2-icon-flemish-militia.png#Aoe2-icon-hussite-wagon.png#Aoe2-icon-serjeant.png#Aoe2de_camel_scout.png#Aoe2de_Chakram.png#Aoe2de_Ghulam.png#Aoe2de_ratha_ranged.png#Aoe2de_shrivamsha_rider.png#Aoe2de_Thirisadai.png#Aoe2de_Urumi.png#Arambaiicon-DE.png#Ballistaelephanticon-DE.png#BerserkIcon-DE.png#BoyarIcon-DE.png#CamelArcherIcon-DE.png#CaravelIcon-DE.png#CataphractIcon-DE.png#Centurion-DE.png#ChukoNuIcon-DE.png#CompositeBowman.png#CondottieroIcon-DE.png#ConquistadorIcon-DE.png#Dromon-DE.png#Flaming_camel_icon.png#GbetoIcon-DE.png#GenitourIcon-DE.png#GenoeseCrossbowmanIcon-DE.png#HuskarlIcon-DE.png#ImperialCamelRiderIcon-DE.png#Imperialskirmishericon-DE.png#JaguarWarriorIcon-DE.png#JanissaryIcon-DE.png#KamayukIcon-DE.png#Karambitwarrioricon-DE.png#Keshikicon.png#Kipchakicon.png#Konnikicon.png#Legionary-DE.png#Leitisicon.png#LongboatIcon-DE.png#LongbowmanIcon-DE.png#MagyarHuszarIcon-DE.png#MamelukeIcon-DE.png#MangudaiIcon-DE.png#MissionaryIcon-DE.png#OrganGunIcon-DE.png#PlumedArcherIcon-DE.png#Rattanarchericon-DE.png#SamuraiIcon-DE.png#Shotelwarrioricon-DE.png#SlingerIcon-DE.png#TarkanIcon-DE.png#TeutonicKnightIcon-DE.png#ThrowingAxemanIcon-DE.png#TurtleShipIcon-DE.png#WarElephantIcon-DE.png#WarWagonIcon-DE.png#WoadRaiderIcon-DE.png#Monaspa.jpg#WarriorPriest.jpg',
-            'university':
-                'ArchitectureDE.png#ArrowSlitsDE.png#BallisticsDE.png#BombardTower_aoe2DE.png#ChemistryDE.png#FortifiedWallDE.png#HeatedShotDE.png#Masonry_aoe2de.png#MurderHolesDE.png#SiegeEngineersDE.png#Tower_aoe2de.png#TreadmillCraneDE.png#University_AoE2_DE.png'
-          };
+    imagesDict =
+    {
+      'age':
+        'AgeUnknown.png#CastleAgeIconDE.png#CastleAgeIconDE_alpha.png#DarkAgeIconDE.png#DarkAgeIconDE_alpha.png#FeudalAgeIconDE.png#FeudalAgeIconDE_alpha.png#ImperialAgeIconDE.png#ImperialAgeIconDE_alpha.png',
+      'animal':
+        'AoE2DE_ingame_goose_icon.png#AoE2DE_ingame_ibex_icon.png#AoE2_DE_box_turtles_icon.png#AoE2_DE_dolphin_icon.png#AoE2_DE_dorado_icon.png#AoE2_DE_marlin_icon.png#AoE2_DE_perch_icon.png#AoE2_DE_salmon_icon.png#AoE2_DE_shore_fish_icon.png#AoE2_DE_snapper_icon.png#AoE2_DE_tuna_icon.png#Boar_aoe2DE.png#CowDE.png#Deer_aoe2DE.png#Elephant_aoe2DE.png#Goat_aoe2DE.png#Llama_aoe2DE.png#Ostrich_icon_aoe2de.png#Pig_aoe2DE.png#Rhinoceros_aoe2DE.png#Sheep_aoe2DE.png#Turkey_aoe2DE.png#Yak_aoe2DE.png#Zebra_aoe2DE.png',
+      'archery_range':
+        'Aoe2de_DOI_elephant_archer_icon.png#ArbalestDE.png#Arbalester_aoe2DE.png#Archery_range_aoe2DE.png#Archer_aoe2DE.png#Cavalryarcher_aoe2DE.png#Crossbowman_aoe2DE.png#ElephantArcherIcon-DE.png#Elite_skirmisher_aoe2DE.png#Hand_cannoneer_aoe2DE.png#Heavycavalryarcher_aoe2de.png#ImperialSkirmisherUpgDE.png#ParthianTacticsDE.png#Skirmisher_aoe2DE.png#ThumbRingDE.png#Heavy-cavalry-archer-resear.jpg',
+      'barracks':
+        'Aoe2-infantry-2-pikeman.png#ArsonDE.png#Barracks_aoe2DE.png#ChampionUpgDE.png#Champion_aoe2DE.png#Eaglescout_aoe2DE.png#EagleWarriorUpgDE.png#Eaglewarrior_aoe2DE.png#EliteEagleWarriorUpgDE.png#EliteEaglewarrior_aoe2DE.png#GambesonsDE.png#HalberdierDE.png#Halberdier_aoe2DE.png#LongSwordmanUpgDE.png#Longswordsman_aoe2DE.png#ManAtArmsUpgDE.png#Manatarms_aoe2DE.png#MilitiaDE.png#PikemanUpDE.png#Spearman_aoe2DE.png#SquiresDE.png#Suplliesicon.png#TwoHandedSwordsmanUpgDE.png#Twohanded_aoe2DE.png',
+      'blacksmith':
+        'Blacksmith_aoe2de.png#BlastFurnaceDE.png#BodkinArrowDE.png#BracerDE.png#ChainBardingDE.png#ChainMailArmorDE.png#FletchingDE.png#Forging_aoe2de.png#IronCastingDE.png#LeatherArcherArmorDE.png#PaddedArcherArmorDE.png#PlateBardingArmorDE.png#PlateMailArmorDE.png#RingArcherArmorDE.png#ScaleBardingArmorDE.png#ScaleMailArmorDE.png',
+      'castle':
+        'CastleAgeUnique.png#Castle_aoe2DE.png#ConscriptionDE.png#HoardingsDE.png#Petard_aoe2DE.png#SapperDE.png#SpiesDE.png#Trebuchet_aoe2DE.png#Unique-tech-imperial.jpg',
+      'civilization':
+        'CivIcon-Armenians.png#CivIcon-Aztecs.png#CivIcon-Bengalis.png#CivIcon-Berbers.png#CivIcon-Bohemians.png#CivIcon-Britons.png#CivIcon-Bulgarians.png#CivIcon-Burgundians.png#CivIcon-Burmese.png#CivIcon-Byzantines.png#CivIcon-Celts.png#CivIcon-Chinese.png#CivIcon-Cumans.png#CivIcon-Dravidians.png#CivIcon-Ethiopians.png#CivIcon-Franks.png#CivIcon-Georgians.png#CivIcon-Goths.png#CivIcon-Gurjaras.png#CivIcon-Hindustanis.png#CivIcon-Huns.png#CivIcon-Incas.png#CivIcon-Indians.png#CivIcon-Italians.png#CivIcon-Japanese.png#CivIcon-Khmer.png#CivIcon-Koreans.png#CivIcon-Lithuanians.png#CivIcon-Magyars.png#CivIcon-Malay.png#CivIcon-Malians.png#CivIcon-Mayans.png#CivIcon-Mongols.png#CivIcon-Persians.png#CivIcon-Poles.png#CivIcon-Portuguese.png#CivIcon-Romans.png#CivIcon-Saracens.png#CivIcon-Sicilians.png#CivIcon-Slavs.png#CivIcon-Spanish.png#CivIcon-Tatars.png#CivIcon-Teutons.png#CivIcon-Turks.png#CivIcon-Vietnamese.png#CivIcon-Vikings.png#question_mark.png#question_mark_black.png',
+      'defensive_structures':
+        'Bombard_tower_aoe2DE.png#Donjon_aoe2DE.png#FortifiedWallDE.png#Gate_aoe2de.png#Krepost_aoe2de.png#Outpost_aoe2de.png#Palisade_gate_aoe2DE.png#Palisade_wall_aoe2de.png#Stone_wall_aoe2de.png#Tower_aoe2de.png',
+      'dock':
+        'Cannon_galleon_aoe2DE.png#CareeningDE.png#Demoraft_aoe2DE.png#Demoship_aoe2DE.png#Dock_aoe2de.png#DryDockDE.png#Elite-cannon-galleon-resear.png#Elite_cannon_galleon_aoe2de.png#Fastfireship_aoe2DE.png#Fireship_aoe2DE.png#Fire_galley_aoe2DE.png#FishingShipDE.png#Fish_trap_aoe2DE.png#GalleonUpgDE.png#Galleon_aoe2DE.png#Galley_aoe2DE.png#GillnetsDE.png#Heavydemoship_aoe2de.png#ShipwrightDE.png#Trade_cog_aoe2DE.png#Transportship_aoe2DE.png#WarGalleyDE.png#War_galley_aoe2DE.png',
+      'lumber_camp':
+        'BowSawDE.png#DoubleBitAxe_aoe2DE.png#Lumber_camp_aoe2de.png#TwoManSawDE.png',
+      'market':
+        'BankingDE.png#CaravanDE.png#CoinageDE.png#GuildsDE.png#Market_aoe2DE.png#Tradecart_aoe2DE.png',
+      'mill':
+        'Aoe2-icon--folwark.png#CropRotationDE.png#FarmDE.png#HeavyPlowDE.png#HorseCollarDE.png#Mill_aoe2de.png',
+      'mining_camp':
+        'GoldMiningDE.png#GoldShaftMiningDE.png#Mining_camp_aoe2de.png#StoneMiningDE.png#StoneShaftMiningDE.png',
+      'monastery':
+        'AtonementDE.png#BlockPrintingDE.png#FaithDE.png#FervorDE.png#FortifiedChurch.png#HerbalDE.png#HeresyDE.png#IlluminationDE.png#MonasteryAoe2DE.png#Monk_aoe2DE.png#RedemptionDE.png#SanctityDE.png#TheocracyDE.png',
+      'other':
+        'Ao2de_caravanserai_icon.png#Feitoria_aoe2DE.png#House_aoe2DE.png#MuleCart.png#Wonder_aoe2DE.png',
+      'resource':
+        'Aoe2de_food.png#Aoe2de_gold.png#Aoe2de_hammer.png#Aoe2de_stone.png#Aoe2de_wood.png#BerryBushDE.png#MaleVillDE_alpha.png#tree.png#MaleVillDE.jpg',
+      'siege_workshop':
+        'AoE2DE_Armored_Elephant_icon.png#AoE2DE_Siege_Elephant_icon.png#Battering_ram_aoe2DE.png#Bombard_cannon_aoe2DE.png#CappedRamDE.png#Capped_ram_aoe2DE.png#HeavyScorpionDE.png#Heavyscorpion_aoe2DE.png#Mangonel_aoe2DE.png#OnagerDE.png#Onager_aoe2DE.png#Scorpion_aoe2DE.png#SiegeOnagerDE.png#Siegetower_aoe2DE.png#Siege_onager_aoe2DE.png#Siege_ram_aoe2DE.png#Siege_workshop_aoe2DE.png#Siege-ram-research.jpg',
+      'stable':
+        'Aoe2de_camel_scout.png#Aoe2_heavycamelriderDE.png#Battle_elephant_aoe2DE.png#BloodlinesDE.png#Camelrider_aoe2DE.png#Cavalier_aoe2DE.png#EliteBattleElephantUpg.png#Elitesteppelancericon.png#EliteSteppeLancerUpgDE.png#Elite_battle_elephant_aoe2DE.png#HeavyCamelUpgDE.png#HusbandryDE.png#Hussar_aoe2DE.png#Hussar_upgrade_aoe2de.png#Knight_aoe2DE.png#Lightcavalry_aoe2DE.png#Paladin_aoe2DE.png#Scoutcavalry_aoe2DE.png#Stable_aoe2DE.png#Steppelancericon.png#Winged-hussar_upgrade.png#Cavalier-research.jpg#Light-cavalry-research.jpg#Paladin-research.jpg',
+      'town_center':
+        'HandcartDE.png#LoomDE.png#Towncenter_aoe2DE.png#TownPatrolDE.png#TownWatchDE.png#WheelbarrowDE.png',
+      'unique_unit':
+        'Aoe2-icon--houfnice.png#Aoe2-icon--obuch.png#Aoe2-icon-coustillier.png#Aoe2-icon-flemish-militia.png#Aoe2-icon-hussite-wagon.png#Aoe2-icon-serjeant.png#Aoe2de_camel_scout.png#Aoe2de_Chakram.png#Aoe2de_Ghulam.png#Aoe2de_ratha_ranged.png#Aoe2de_shrivamsha_rider.png#Aoe2de_Thirisadai.png#Aoe2de_Urumi.png#Arambaiicon-DE.png#Ballistaelephanticon-DE.png#BerserkIcon-DE.png#BoyarIcon-DE.png#CamelArcherIcon-DE.png#CaravelIcon-DE.png#CataphractIcon-DE.png#Centurion-DE.png#ChukoNuIcon-DE.png#CompositeBowman.png#CondottieroIcon-DE.png#ConquistadorIcon-DE.png#Dromon-DE.png#Flaming_camel_icon.png#GbetoIcon-DE.png#GenitourIcon-DE.png#GenoeseCrossbowmanIcon-DE.png#HuskarlIcon-DE.png#ImperialCamelRiderIcon-DE.png#Imperialskirmishericon-DE.png#JaguarWarriorIcon-DE.png#JanissaryIcon-DE.png#KamayukIcon-DE.png#Karambitwarrioricon-DE.png#Keshikicon.png#Kipchakicon.png#Konnikicon.png#Legionary-DE.png#Leitisicon.png#LongboatIcon-DE.png#LongbowmanIcon-DE.png#MagyarHuszarIcon-DE.png#MamelukeIcon-DE.png#MangudaiIcon-DE.png#MissionaryIcon-DE.png#OrganGunIcon-DE.png#PlumedArcherIcon-DE.png#Rattanarchericon-DE.png#SamuraiIcon-DE.png#Shotelwarrioricon-DE.png#SlingerIcon-DE.png#TarkanIcon-DE.png#TeutonicKnightIcon-DE.png#ThrowingAxemanIcon-DE.png#TurtleShipIcon-DE.png#WarElephantIcon-DE.png#WarWagonIcon-DE.png#WoadRaiderIcon-DE.png#Monaspa.jpg#WarriorPriest.jpg',
+      'university':
+        'ArchitectureDE.png#ArrowSlitsDE.png#BallisticsDE.png#BombardTower_aoe2DE.png#ChemistryDE.png#FortifiedWallDE.png#HeatedShotDE.png#Masonry_aoe2de.png#MurderHolesDE.png#SiegeEngineersDE.png#Tower_aoe2de.png#TreadmillCraneDE.png#University_AoE2_DE.png'
+    };
 
   // Split each string (e.g. 'image_0#image_1#image_2') in a list of images.
   for (const [key, value] of Object.entries(imagesDict)) {
@@ -4390,7 +4420,7 @@ function getInstructionsAoE2() {
     'click on \'Copy to clipboard for RTS Overlay\', then paste the content in the text panel below.'
   ];
   return contentArrayToDiv(
-      getArrayInstructions(true, selectFactionLines, externalBOLines));
+    getArrayInstructions(true, selectFactionLines, externalBOLines));
 }
 
 /**
@@ -4444,7 +4474,7 @@ function openSinglePanelPageAoE2() {
       2: getBOImageHTML(game + 'age/FeudalAgeIconDE_alpha.png') + 'Feudal Age',
       3: getBOImageHTML(game + 'age/CastleAgeIconDE_alpha.png') + 'Castle Age',
       4: getBOImageHTML(game + 'age/ImperialAgeIconDE_alpha.png') +
-          'Imperial Age'
+        'Imperial Age'
     }
   };
 
@@ -4472,29 +4502,29 @@ function getResourceLineAoE4(currentStep) {
   const resources = currentStep.resources;
 
   htmlString +=
-      getBOImageValue(resourceFolder + 'resource_food.png', resources, 'food');
+    getBOImageValue(resourceFolder + 'resource_food.png', resources, 'food');
   htmlString +=
-      getBOImageValue(resourceFolder + 'resource_wood.png', resources, 'wood');
+    getBOImageValue(resourceFolder + 'resource_wood.png', resources, 'wood');
   htmlString +=
-      getBOImageValue(resourceFolder + 'resource_gold.png', resources, 'gold');
+    getBOImageValue(resourceFolder + 'resource_gold.png', resources, 'gold');
   htmlString += getBOImageValue(
-      resourceFolder + 'resource_stone.png', resources, 'stone');
+    resourceFolder + 'resource_stone.png', resources, 'stone');
   htmlString += getBOImageValue(
-      resourceFolder + 'repair.png', resources, 'builder', true);
+    resourceFolder + 'repair.png', resources, 'builder', true);
   htmlString += getBOImageValue(
-      gamePicturesFolder + 'unit_worker/villager.png', currentStep,
-      'villager_count', true);
+    gamePicturesFolder + 'unit_worker/villager.png', currentStep,
+    'villager_count', true);
   htmlString += getBOImageValue(
-      gamePicturesFolder + 'building_economy/house.png', currentStep,
-      'population_count', true);
+    gamePicturesFolder + 'building_economy/house.png', currentStep,
+    'population_count', true);
 
   // Age image
   const ageImage =
-      {1: 'age_1.png', 2: 'age_2.png', 3: 'age_3.png', 4: 'age_4.png'};
+    { 1: 'age_1.png', 2: 'age_2.png', 3: 'age_3.png', 4: 'age_4.png' };
 
   if (currentStep.age in ageImage) {
     htmlString +=
-        getBOImageHTML(gamePicturesFolder + 'age/' + ageImage[currentStep.age]);
+      getBOImageHTML(gamePicturesFolder + 'age/' + ageImage[currentStep.age]);
   }
 
   return htmlString;
@@ -4557,12 +4587,12 @@ function getBOStepAoE4(builOrderData) {
     const data = builOrderData.at(-1);  // Last step data
     return {
       'population_count':
-          ('population_count' in data) ? data['population_count'] : -1,
+        ('population_count' in data) ? data['population_count'] : -1,
       'villager_count': ('villager_count' in data) ? data['villager_count'] : 0,
       'age': ('age' in data) ? data['age'] : 1,
       'resources': ('resources' in data) ?
-          data['resources'] :
-          {'food': 0, 'wood': 0, 'gold': 0, 'stone': 0},
+        data['resources'] :
+        { 'food': 0, 'wood': 0, 'gold': 0, 'stone': 0 },
       'notes': ['Note 1', 'Note 2']
     };
   } else {
@@ -4570,7 +4600,7 @@ function getBOStepAoE4(builOrderData) {
       'population_count': -1,
       'villager_count': 0,
       'age': 1,
-      'resources': {'food': 0, 'wood': 0, 'gold': 0, 'stone': 0},
+      'resources': { 'food': 0, 'wood': 0, 'gold': 0, 'stone': 0 },
       'notes': ['Note 1', 'Note 2']
     };
   }
@@ -4604,7 +4634,7 @@ function getBOTemplateAoE4() {
 function updateTownCenterTimeAoE4(initialTime, civilizationFlags, currentAge) {
   if (civilizationFlags['French']) {
     return initialTime /
-        (1.0 + 0.05 * (currentAge + 1));  // 10%/15%/20%/25% faster
+      (1.0 + 0.05 * (currentAge + 1));  // 10%/15%/20%/25% faster
   } else {
     return initialTime;
   }
@@ -4623,7 +4653,7 @@ function getVillagerTimeAoE4(civilizationFlags, currentAge) {
     return 23.0;
   } else {  // generic
     console.assert(
-        1 <= currentAge && currentAge <= 4, 'Age expected in [1;4].');
+      1 <= currentAge && currentAge <= 4, 'Age expected in [1;4].');
     return updateTownCenterTimeAoE4(20.0, civilizationFlags, currentAge);
   }
 }
@@ -4639,7 +4669,7 @@ function getVillagerTimeAoE4(civilizationFlags, currentAge) {
  * @returns Requested research time [sec].
  */
 function getTownCenterUnitResearchTimeAoE4(
-    name, civilizationFlags, currentAge) {
+  name, civilizationFlags, currentAge) {
   console.assert(1 <= currentAge && currentAge <= 4, 'Age expected in [1;4].');
   if (name === 'textiles') {
     if (civilizationFlags['Delhi']) {
@@ -4705,7 +4735,7 @@ function evaluateBOTimingAoE4(timeOffset) {
 
   if (!('build_order' in dataBO)) {
     console.log(
-        'Warning: the \'build_order\' field is missing from data when evaluating the timing.')
+      'Warning: the \'build_order\' field is missing from data when evaluating the timing.')
     return;
   }
 
@@ -4723,8 +4753,8 @@ function evaluateBOTimingAoE4(timeOffset) {
     if (villagerCount < 0) {
       const resources = currentStep['resources'];
       villagerCount = Math.max(0, resources['wood']) +
-          Math.max(0, resources['food']) + Math.max(0, resources['gold']) +
-          Math.max(0, resources['stone']);
+        Math.max(0, resources['food']) + Math.max(0, resources['gold']) +
+        Math.max(0, resources['stone']);
       if ('builder' in resources) {
         villagerCount += Math.max(0, resources['builder']);
       }
@@ -4735,27 +4765,27 @@ function evaluateBOTimingAoE4(timeOffset) {
     lastVillagerCount = villagerCount;
 
     stepTotalTime += updateVillagerCount *
-        getVillagerTimeAoE4(civilizationFlags, currentAge);
+      getVillagerTimeAoE4(civilizationFlags, currentAge);
 
     // next age
     const nextAge = (1 <= currentStep['age'] && currentStep['age'] <= 4) ?
-        currentStep['age'] :
-        currentAge;
+      currentStep['age'] :
+      currentAge;
 
     // Jeanne becomes a soldier in Feudal
     if (civilizationFlags['Jeanne'] && !jeanneMilitaryFlag && (nextAge > 1)) {
       stepTotalTime += get_villager_time(
-          civilizationFlags, currentAge);  // one extra villager to create
+        civilizationFlags, currentAge);  // one extra villager to create
       jeanneMilitaryFlag = true;
     }
 
     // Check for TC technologies or special units in notes
     for (note of currentStep['notes']) {
       for (const [tcItemName, tcItemImage] of Object.entries(
-               TCUnitTechnologies)) {
+        TCUnitTechnologies)) {
         if (note.includes('@' + tcItemImage + '@')) {
           stepTotalTime += getTownCenterUnitResearchTimeAoE4(
-              tcItemName, civilizationFlags, currentAge);
+            tcItemName, civilizationFlags, currentAge);
         }
       }
     }
@@ -4771,7 +4801,7 @@ function evaluateBOTimingAoE4(timeOffset) {
     // Special case for last step
     // (add 1 sec to avoid displaying both at the same time).
     if ((currentStepID === stepCount - 1) && (stepCount >= 2) &&
-        (currentStep['time'] === buildOrderData[currentStepID - 1]['time'])) {
+      (currentStep['time'] === buildOrderData[currentStepID - 1]['time'])) {
       currentStep['time'] = buildOrderTimeToStr(Math.round(lastTimeSec + 1.0));
     }
   }
@@ -4785,150 +4815,150 @@ function evaluateBOTimingAoE4(timeOffset) {
 function getImagesAoE4() {
   // This is obtained using the 'python/utilities/list_images.py' script.
   const imagesDict =
-      {
-        'abilities': 'attack-move.png#repair.png',
-        'ability_chinese': 'collect_tax.png#supervise.png',
-        'ability_jeanne':
-            'ability-champion-companions-1.png#ability-consecrate-1.png#ability-divine-arrow-1.png#ability-divine-restoration-1.png#ability-field-commander-1.png#ability-gunpowder-monarch-1.png#ability-holy-wrath-1.png#ability-path-of-the-archer-1.png#ability-path-of-the-warrior-1.png#ability-rider-companions-1.png#ability-riders-ready-1.png#ability-strength-of-heaven-1.png#ability-to-arms-men-1.png#ability-valorous-inspiration-1.png',
-        'age':
-            'age_1.png#age_2.png#age_3.png#age_4.png#age_unknown.png#goldenagetier1.png#goldenagetier2.png#goldenagetier3.png#goldenagetier4.png#goldenagetier5.png#vizier_point.png',
-        'building_byzantines':
-            'aqueduct-1.png#cistern-1.png#mercenary-house-2.png#olive-grove-1.png',
-        'building_chinese': 'granary.png#pagoda.png#village.png',
-        'building_defensive':
-            'keep.png#outpost.png#palisade-gate.png#palisade-wall.png#stone-wall-gate.png#stone-wall-tower.png#stone-wall.png',
-        'building_economy':
-            'farm.png#house.png#lumber-camp.png#market.png#mill.png#mining-camp.png#town-center.png',
-        'building_japanese':
-            'buddhist-temple-3.png#castle-4.png#farmhouse-1.png#forge-1.png#shinto-shrine-3.png',
-        'building_malians':
-            'cattle-ranch-2.png#pit-mine-1.png#toll-outpost-1.png',
-        'building_military':
-            'archery-range.png#barracks.png#dock.png#siege-workshop.png#stable.png',
-        'building_mongols': 'ger.png#ovoo.png#pasture.png#prayer-tent.png',
-        'building_ottomans': 'military-school-1.png',
-        'building_religious': 'monastery.png#mosque.png',
-        'building_rus':
-            'fortified-palisade-gate.png#fortified-palisade-wall.png#hunting-cabin.png#wooden-fortress.png',
-        'building_technology': 'blacksmith.png#madrasa.png#university.png',
-        'civilization_flag':
-            'abb.png#ayy.png#byz.png#chi.png#CivIcon-AbbasidAoE4.png#CivIcon-AbbasidAoE4_spacing.png#CivIcon-AyyubidsAoE4.png#CivIcon-AyyubidsAoE4_spacing.png#CivIcon-ByzantinesAoE4.png#CivIcon-ByzantinesAoE4_spacing.png#CivIcon-ChineseAoE4.png#CivIcon-ChineseAoE4_spacing.png#CivIcon-DelhiAoE4.png#CivIcon-DelhiAoE4_spacing.png#CivIcon-EnglishAoE4.png#CivIcon-EnglishAoE4_spacing.png#CivIcon-FrenchAoE4.png#CivIcon-FrenchAoE4_spacing.png#CivIcon-HREAoE4.png#CivIcon-HREAoE4_spacing.png#CivIcon-JapaneseAoE4.png#CivIcon-JapaneseAoE4_spacing.png#CivIcon-JeanneDArcAoE4.png#CivIcon-JeanneDArcAoE4_spacing.png#CivIcon-MaliansAoE4.png#CivIcon-MaliansAoE4_spacing.png#CivIcon-MongolsAoE4.png#CivIcon-MongolsAoE4_spacing.png#CivIcon-OrderOfTheDragonAoE4.png#CivIcon-OrderOfTheDragonAoE4_spacing.png#CivIcon-OttomansAoE4.png#CivIcon-OttomansAoE4_spacing.png#CivIcon-RusAoE4.png#CivIcon-RusAoE4_spacing.png#CivIcon-ZhuXiLegacyAoE4.png#CivIcon-ZhuXiLegacyAoE4_spacing.png#del.png#dra.png#eng.png#fre.png#hre.png#jap.png#jda.png#mal.png#mon.png#ott.png#rus.png#zxl.png',
-        'landmark_abbasid':
-            'culture-wing.png#economic-wing.png#house-of-wisdom.png#military-wing.png#prayer-hall-of-uqba.png#trade-wing.png',
-        'landmark_byzantines':
-            'cathedral-of-divine-wisdom-4.png#cistern-of-the-first-hill-2.png#foreign-engineering-company-3.png#golden-horn-tower-2.png#grand-winery-1.png#imperial-hippodrome-1.png#palatine-school-3.png',
-        'landmark_chinese':
-            'astronomical-clocktower.png#barbican-of-the-sun.png#enclave-of-the-emperor.png#great-wall-gatehouse.png#imperial-academy.png#imperial-palace.png#spirit-way.png',
-        'landmark_delhi':
-            'compound-of-the-defender.png#dome-of-the-faith.png#great-palace-of-agra.png#hisar-academy.png#house-of-learning.png#palace-of-the-sultan.png#tower-of-victory.png',
-        'landmark_english':
-            'abbey-of-kings.png#berkshire-palace.png#cathedral-of-st-thomas.png#council-hall.png#kings-palace.png#the-white-tower.png#wynguard-palace.png',
-        'landmark_french':
-            'chamber-of-commerce.png#college-of-artillery.png#guild-hall.png#notre-dame.png#red-palace.png#royal-institute.png#school-of-cavalry.png',
-        'landmark_hre': 'aachen-chapel.png#burgrave-palace.png#elzbach-palace.png#great-palace-of-flensburg.png#meinwerk-palace.png#palace-of-swabia.png#regnitz-cathedral.png',
-        'landmark_japanese':
-            'castle-of-the-crow-4.png#floating-gate-2.png#koka-township-1.png#kura-storehouse-1.png#tanegashima-gunsmith-3.png#temple-of-equality-2.png#tokugawa-shrine-4.png',
-        'landmark_malians':
-            'farimba-garrison-2.png#fort-of-the-huntress-3.png#grand-fulani-corral-2.png#great-mosque-4.png#griot-bara-3.png#mansa-quarry-2.png#saharan-trade-network-1.png',
-        'landmark_mongols':
-            'deer-stones.png#khaganate-palace.png#kurultai.png#monument-of-the-great-khan.png#steppe-redoubt.png#the-silver-tree.png#the-white-stupa.png',
-        'landmark_ottomans':
-            'azure-mosque-4.png#istanbul-imperial-palace-2.png#istanbul-observatory-3.png#mehmed-imperial-armory-2.png#sea-gate-castle-3.png#sultanhani-trade-network-1.png#twin-minaret-medrese-1.png',
-        'landmark_rus':
-            'abbey-of-the-trinity.png#cathedral-of-the-tsar.png#high-armory.png#high-trade-house.png#kremlin.png#spasskaya-tower.png#the-golden-gate.png',
-        'landmark_zhuxi':
-            'jiangnan-tower-2.png#meditation-gardens-1.png#mount-lu-academy-1.png#shaolin-monastery-2.png#temple-of-the-sun-3.png#zhu-xis-library-3.png',
-        'rank':
-            'bronze_1.png#bronze_2.png#bronze_3.png#conqueror_1.png#conqueror_2.png#conqueror_3.png#diamond_1.png#diamond_2.png#diamond_3.png#gold_1.png#gold_2.png#gold_3.png#platinum_1.png#platinum_2.png#platinum_3.png#silver_1.png#silver_2.png#silver_3.png',
-        'resource':
-            'berrybush.png#boar.png#bounty.png#cattle.png#deer.png#fish.png#gaiatreeprototypetree.png#oliveoil.png#rally.png#relics.png#repair.png#resource_food.png#resource_gold.png#resource_stone.png#resource_wood.png#sacred_sites.png#sheep.png#wolf.png',
-        'technology_abbasid':
-            'agriculture.png#armored-caravans.png#boot-camp.png#camel-handling.png#camel-rider-barding-4.png#camel-rider-shields.png#camel-support.png#composite-bows.png#faith.png#fertile-crescent-2.png#fresh-foodstuffs.png#grand-bazaar.png#improved-processing.png#medical-centers.png#phalanx.png#preservation-of-knowledge.png#public-library.png#spice-roads.png#teak-masts.png',
-        'technology_ayyubids':
-            'culture-wing-advancement-1.png#culture-wing-logistics-1.png#economic-wing-growth-1.png#economic-wing-industry-1.png#infantry-support-4.png#military-wing-master-smiths-1.png#military-wing-reinforcement-1.png#phalanx-2.png#siege-carpentry-3.png#sultans-mamluks-3.png#trade-wing-advisors-1.png#trade-wing-bazaar-1.png',
-        'technology_byzantines':
-            'border-settlements-2.png#eastern-mercenary-contract-1.png#elite-mercenaries-4.png#expilatores-2.png#ferocious-speed-4.png#greek-fire-projectiles-4.png#heavy-dromon-3.png#liquid-explosives-3.png#numeri-4.png#silk-road-mercenary-contract-1.png#teardrop-shields-3.png#trapezites-2.png#veteran-mercenaries-3.png#western-mercenary-contract-1.png',
-        'technology_chinese':
-            'ancient-techniques.png#battle-hardened.png#extra-hammocks.png#extra-materials.png#handcannon-slits.png#imperial-examination.png#pyrotechnics.png#reload-drills.png#reusable-barrels.png#thunderclap-bombs-4.png',
-        'technology_defensive':
-            'arrow-slits.png#boiling-oil.png#cannon-emplacement.png#court-architects.png#fortify-outpost.png#springald-emplacement.png',
-        'technology_delhi':
-            'all-seeing-eye.png#armored-beasts.png#efficient-production.png#forced-march.png#hearty-rations.png#honed-blades.png#lookout-towers.png#mahouts.png#manuscript-trade-1.png#paiks.png#reinforced-foundations.png#sanctity.png#siege-elephant.png#slow-burning-defenses.png#swiftness.png#tranquil-venue.png#village-fortresses.png#zeal.png',
-        'technology_dragon':
-            'bodkin-bolts-4.png#dragon-fire-2.png#dragon-scale-leather-3.png#golden-cuirass-2.png#war-horses-4.png#zornhau-3.png',
-        'technology_economy':
-            'acid-distilization.png#crosscut-saw.png#cupellation.png#double-broadaxe.png#drift-nets.png#extended-lines.png#fertilization.png#forestry.png#horticulture.png#lumber-preservation.png#precision-cross-breeding.png#professional-scouts.png#specialized-pick.png#survival-techniques.png#textiles.png#wheelbarrow.png',
-        'technology_english':
-            'admiralty-2.png#armor-clad.png#arrow-volley.png#enclosures.png#network-of-citadels.png#setup-camp.png#shattering-projectiles.png',
-        'technology_french':
-            'cantled-saddles.png#chivalry.png#crossbow-stirrups.png#enlistment-incentives.png#gambesons.png#long-guns.png#merchant-guilds-4.png#royal-bloodlines.png',
-        'technology_hre':
-            'benediction.png#devoutness.png#fire-stations.png#heavy-maces.png#inspired-warriors.png#marching-drills.png#reinforced-defenses.png#riveted-chain-mail-2.png#slate-and-stone-construction.png#steel-barding-3.png#two-handed-weapon.png',
-        'technology_japanese':
-            'bunrei.png#copper-plating-3.png#daimyo-manor-1.png#daimyo-palace-2.png#do-maru-armor-4.png#explosives-4.png#five_ministries.png#fudasashi-3.png#gion_festival.png#heated-shot-4.png#hizukuri-2.png#kabura-ya-whistling-arrow-3.png#kobuse-gitae-3.png#nagae-yari-4.png#nehan.png#oda-tactics-4.png#odachi-3.png#shinto_rituals.png#shogunate-castle-3.png#swivel-cannon-4.png#takezaiku-2.png#tatara-1.png#towara-1.png#yaki-ire-4.png#zen.png',
-        'technology_jeanne':
-            'companion-equipment-3.png#ordinance-company-3.png',
-        'technology_malians':
-            'banco-repairs-2.png#canoe-tactics-2.png#farima-leadership-4.png#imported-armor-3.png#local-knowledge-4.png#poisoned-arrows-3.png#precision-training-4.png',
-        'technology_military':
-            'angled-surfaces.png#balanced-projectiles.png#biology.png#bloomery.png#chemistry.png#damascus-steel.png#decarbonization.png#elite-army-tactics.png#fitted-leatherwork.png#geometry.png#greased-axles.png#incendiary-arrows.png#insulated-helm.png#iron-undermesh.png#master-smiths.png#military-academy.png#platecutter-point.png#siege-engineering.png#siege-works.png#steeled-arrow.png#wedge-rivets.png',
-        'technology_mongols':
-            'additional-torches.png#monastic-shrines.png#piracy.png#raid-bounty.png#siha-bow-limbs.png#steppe-lancers.png#stone-bounty.png#stone-commerce.png#superior-mobility.png#whistling-arrows.png#yam-network.png',
-        'technology_naval':
-            'additional-sails.png#armored-hull.png#chaser-cannons.png#explosives.png#extra-ballista.png#incendiaries-3.png#naval-arrow-slits.png#navigator-lookout.png#shipwrights-4.png#springald-crews-3.png',
-        'technology_ottomans':
-            'advanced-academy-1.png#anatolian-hills-1.png#fast-training-1.png#field-work-1.png#great-bombard-emplacement.png#imperial-fleet-4.png#janissary-company-1.png#janissary-guns-4.png#mehter-drums-1.png#military-campus-1.png#siege-crews-1.png#trade-bags-1.png',
-        'technology_religious': 'herbal-medicine.png#piety.png#tithe-barns.png',
-        'technology_rus':
-            'adaptable-hulls-3.png#banded-arms.png#blessing-duration.png#boyars-fortitude.png#castle-turret.png#castle-watch.png#cedar-hulls.png#clinker-construction.png#double-time.png#fine-tuned-guns.png#improved-blessing.png#knight-sabers.png#mounted-training.png#saints-reach.png#saints-veneration-4.png#siege-crew-training.png#wandering-town.png#warrior_scout_2.png',
-        'technology_units':
-            'adjustable-crossbars.png#lightweight-beams-4.png#roller-shutter-triggers.png#spyglass-4.png',
-        'technology_zhuxi':
-            '10000-bolts-4.png#advanced-administration-4.png#cloud-of-terror-4.png#dynastic-protectors-4.png#imperial-red-seals-3.png#military-affairs-bureau-1.png#roar-of-the-dragon-4.png',
-        'unit_abbasid':
-            'camel-archer-2.png#camel-rider-3.png#ghulam-3.png#imam.png',
-        'unit_ayyubids':
-            'atabeg-1.png#bedouin-skirmisher-2.png#bedouin-swordsman-1.png#camel-lancer-3.png#dervish-3.png#desert-raider-2.png#manjaniq-3.png#tower-of-the-sultan-3.png',
-        'unit_byzantines':
-            'arbaletrier-3.png#camel-archer-2.png#camel-rider-3.png#cataphract-3.png#cheirosiphon-3.png#desert-raider-2.png#dromon-2.png#ghulam-3.png#grenadier-4.png#horse-archer-3.png#javelin-thrower-2.png#keshik-2.png#landsknecht-3.png#limitanei-1.png#longbowman-2.png#mangudai.png#musofadi-warrior-2.png#royal-knight-2.png#sipahi-2.png#streltsy.png#tower-elephant-3.png#tower-of-the-sultan-3.png#varangian-guard-3.png#war-elephant.png#zhuge-nu-2.png',
-        'unit_cavalry':
-            'horseman-1.png#knight-2.png#lancer-3.png#lancer-4.png#scout.png',
-        'unit_chinese':
-            'fire-lancer-3.png#grenadier-4.png#imperial-official.png#junk.png#nest-of-bees.png#palace-guard-3.png#zhuge-nu-2.png',
-        'unit_delhi':
-            'ghazi-raider-2.png#scholar.png#sultans-elite-tower-elephant-4.png#tower-elephant-3.png#war-elephant.png',
-        'unit_dragon':
-            'dragon-handcannoneer-4.png#gilded-archer-2.png#gilded-crossbowman-3.png#gilded-horseman-2.png#gilded-knight-3.png#gilded-landsknecht-3.png#gilded-man-at-arms-2.png#gilded-spearman-1.png',
-        'unit_english':
-            'king-2.png#longbowman-2.png#wynguard-army-1.png#wynguard-footmen-1.png#wynguard-raiders-1.png#wynguard-ranger-4.png',
-        'unit_events': 'land_monster.png#water_monster.png',
-        'unit_french':
-            'arbaletrier-3.png#cannon-4.png#galleass.png#royal-cannon-4.png#royal-culverin-4.png#royal-knight-2.png#royal-ribauldequin-4.png#war-cog.png',
-        'unit_hre': 'landsknecht-3.png#prelate.png',
-        'unit_infantry':
-            'archer-2.png#crossbowman-3.png#handcannoneer-4.png#man-at-arms-1.png#spearman-1.png',
-        'unit_japanese':
-            'atakebune-4.png#buddhist-monk-3.png#katana-bannerman-2.png#mounted-samurai-3.png#onna-bugeisha-2.png#onna-musha-3.png#ozutsu-4.png#samurai-1.png#shinobi-2.png#shinto-priest-3.png#uma-bannerman-2.png#yumi-ashigaru-2.png#yumi-bannerman-2.png',
-        'unit_jeanne':
-            'jeanne-darc-blast-cannon-4.png#jeanne-darc-hunter-2.png#jeanne-darc-knight-3.png#jeanne-darc-markswoman-4.png#jeanne-darc-mounted-archer-3.png#jeanne-darc-peasant-1.png#jeanne-darc-woman-at-arms-2.png#jeannes-champion-3.png#jeannes-rider-3.png',
-        'unit_malians':
-            'donso-1.png#hunting-canoe-2.png#javelin-thrower-2.png#musofadi-gunner-4.png#musofadi-warrior-2.png#sofa-2.png#war-canoe-2.png#warrior-scout-2.png',
-        'unit_mongols':
-            'huihui-pao-1.png#keshik-2.png#khan-1.png#khans-hunter.png#light-junk.png#mangudai.png#shaman.png#traction-trebuchet.png',
-        'unit_ottomans':
-            'grand-galley-4.png#great-bombard-4.png#janissary-3.png#mehter-2.png#scout-ship-2.png#sipahi-2.png',
-        'unit_religious': 'imam-3.png#monk-3.png',
-        'unit_rus':
-            'horse-archer-3.png#lodya-attack-ship.png#lodya-demolition-ship.png#lodya-fishing-boat.png#lodya-galley-3.png#lodya-trade-ship.png#lodya-transport-ship.png#militia-2.png#streltsy.png#warrior-monk.png',
-        'unit_ship':
-            'baghlah.png#baochuan.png#carrack.png#demolition-ship.png#dhow.png#explosive-dhow.png#explosive-junk.png#fishing-boat.png#galley.png#hulk.png#junk-3.png#light-junk-2.png#trade-ship.png#transport-ship.png#war-junk.png#xebec.png',
-        'unit_siege':
-            'battering-ram.png#bombard.png#culverin-4.png#mangonel-3.png#ribauldequin-4.png#siege-tower.png#springald.png#trebuchet.png',
-        'unit_worker':
-            'monk-3.png#trader.png#villager-abbasid.png#villager-china.png#villager-delhi.png#villager-japanese.png#villager-malians.png#villager-mongols.png#villager-ottomans.png#villager.png',
-        'unit_zhuxi':
-            'imperial-guard-1.png#shaolin-monk-3.png#yuan-raider-4.png'
-      };
+  {
+    'abilities': 'attack-move.png#repair.png',
+    'ability_chinese': 'collect_tax.png#supervise.png',
+    'ability_jeanne':
+      'ability-champion-companions-1.png#ability-consecrate-1.png#ability-divine-arrow-1.png#ability-divine-restoration-1.png#ability-field-commander-1.png#ability-gunpowder-monarch-1.png#ability-holy-wrath-1.png#ability-path-of-the-archer-1.png#ability-path-of-the-warrior-1.png#ability-rider-companions-1.png#ability-riders-ready-1.png#ability-strength-of-heaven-1.png#ability-to-arms-men-1.png#ability-valorous-inspiration-1.png',
+    'age':
+      'age_1.png#age_2.png#age_3.png#age_4.png#age_unknown.png#goldenagetier1.png#goldenagetier2.png#goldenagetier3.png#goldenagetier4.png#goldenagetier5.png#vizier_point.png',
+    'building_byzantines':
+      'aqueduct-1.png#cistern-1.png#mercenary-house-2.png#olive-grove-1.png',
+    'building_chinese': 'granary.png#pagoda.png#village.png',
+    'building_defensive':
+      'keep.png#outpost.png#palisade-gate.png#palisade-wall.png#stone-wall-gate.png#stone-wall-tower.png#stone-wall.png',
+    'building_economy':
+      'farm.png#house.png#lumber-camp.png#market.png#mill.png#mining-camp.png#town-center.png',
+    'building_japanese':
+      'buddhist-temple-3.png#castle-4.png#farmhouse-1.png#forge-1.png#shinto-shrine-3.png',
+    'building_malians':
+      'cattle-ranch-2.png#pit-mine-1.png#toll-outpost-1.png',
+    'building_military':
+      'archery-range.png#barracks.png#dock.png#siege-workshop.png#stable.png',
+    'building_mongols': 'ger.png#ovoo.png#pasture.png#prayer-tent.png',
+    'building_ottomans': 'military-school-1.png',
+    'building_religious': 'monastery.png#mosque.png',
+    'building_rus':
+      'fortified-palisade-gate.png#fortified-palisade-wall.png#hunting-cabin.png#wooden-fortress.png',
+    'building_technology': 'blacksmith.png#madrasa.png#university.png',
+    'civilization_flag':
+      'abb.png#ayy.png#byz.png#chi.png#CivIcon-AbbasidAoE4.png#CivIcon-AbbasidAoE4_spacing.png#CivIcon-AyyubidsAoE4.png#CivIcon-AyyubidsAoE4_spacing.png#CivIcon-ByzantinesAoE4.png#CivIcon-ByzantinesAoE4_spacing.png#CivIcon-ChineseAoE4.png#CivIcon-ChineseAoE4_spacing.png#CivIcon-DelhiAoE4.png#CivIcon-DelhiAoE4_spacing.png#CivIcon-EnglishAoE4.png#CivIcon-EnglishAoE4_spacing.png#CivIcon-FrenchAoE4.png#CivIcon-FrenchAoE4_spacing.png#CivIcon-HREAoE4.png#CivIcon-HREAoE4_spacing.png#CivIcon-JapaneseAoE4.png#CivIcon-JapaneseAoE4_spacing.png#CivIcon-JeanneDArcAoE4.png#CivIcon-JeanneDArcAoE4_spacing.png#CivIcon-MaliansAoE4.png#CivIcon-MaliansAoE4_spacing.png#CivIcon-MongolsAoE4.png#CivIcon-MongolsAoE4_spacing.png#CivIcon-OrderOfTheDragonAoE4.png#CivIcon-OrderOfTheDragonAoE4_spacing.png#CivIcon-OttomansAoE4.png#CivIcon-OttomansAoE4_spacing.png#CivIcon-RusAoE4.png#CivIcon-RusAoE4_spacing.png#CivIcon-ZhuXiLegacyAoE4.png#CivIcon-ZhuXiLegacyAoE4_spacing.png#del.png#dra.png#eng.png#fre.png#hre.png#jap.png#jda.png#mal.png#mon.png#ott.png#rus.png#zxl.png',
+    'landmark_abbasid':
+      'culture-wing.png#economic-wing.png#house-of-wisdom.png#military-wing.png#prayer-hall-of-uqba.png#trade-wing.png',
+    'landmark_byzantines':
+      'cathedral-of-divine-wisdom-4.png#cistern-of-the-first-hill-2.png#foreign-engineering-company-3.png#golden-horn-tower-2.png#grand-winery-1.png#imperial-hippodrome-1.png#palatine-school-3.png',
+    'landmark_chinese':
+      'astronomical-clocktower.png#barbican-of-the-sun.png#enclave-of-the-emperor.png#great-wall-gatehouse.png#imperial-academy.png#imperial-palace.png#spirit-way.png',
+    'landmark_delhi':
+      'compound-of-the-defender.png#dome-of-the-faith.png#great-palace-of-agra.png#hisar-academy.png#house-of-learning.png#palace-of-the-sultan.png#tower-of-victory.png',
+    'landmark_english':
+      'abbey-of-kings.png#berkshire-palace.png#cathedral-of-st-thomas.png#council-hall.png#kings-palace.png#the-white-tower.png#wynguard-palace.png',
+    'landmark_french':
+      'chamber-of-commerce.png#college-of-artillery.png#guild-hall.png#notre-dame.png#red-palace.png#royal-institute.png#school-of-cavalry.png',
+    'landmark_hre': 'aachen-chapel.png#burgrave-palace.png#elzbach-palace.png#great-palace-of-flensburg.png#meinwerk-palace.png#palace-of-swabia.png#regnitz-cathedral.png',
+    'landmark_japanese':
+      'castle-of-the-crow-4.png#floating-gate-2.png#koka-township-1.png#kura-storehouse-1.png#tanegashima-gunsmith-3.png#temple-of-equality-2.png#tokugawa-shrine-4.png',
+    'landmark_malians':
+      'farimba-garrison-2.png#fort-of-the-huntress-3.png#grand-fulani-corral-2.png#great-mosque-4.png#griot-bara-3.png#mansa-quarry-2.png#saharan-trade-network-1.png',
+    'landmark_mongols':
+      'deer-stones.png#khaganate-palace.png#kurultai.png#monument-of-the-great-khan.png#steppe-redoubt.png#the-silver-tree.png#the-white-stupa.png',
+    'landmark_ottomans':
+      'azure-mosque-4.png#istanbul-imperial-palace-2.png#istanbul-observatory-3.png#mehmed-imperial-armory-2.png#sea-gate-castle-3.png#sultanhani-trade-network-1.png#twin-minaret-medrese-1.png',
+    'landmark_rus':
+      'abbey-of-the-trinity.png#cathedral-of-the-tsar.png#high-armory.png#high-trade-house.png#kremlin.png#spasskaya-tower.png#the-golden-gate.png',
+    'landmark_zhuxi':
+      'jiangnan-tower-2.png#meditation-gardens-1.png#mount-lu-academy-1.png#shaolin-monastery-2.png#temple-of-the-sun-3.png#zhu-xis-library-3.png',
+    'rank':
+      'bronze_1.png#bronze_2.png#bronze_3.png#conqueror_1.png#conqueror_2.png#conqueror_3.png#diamond_1.png#diamond_2.png#diamond_3.png#gold_1.png#gold_2.png#gold_3.png#platinum_1.png#platinum_2.png#platinum_3.png#silver_1.png#silver_2.png#silver_3.png',
+    'resource':
+      'berrybush.png#boar.png#bounty.png#cattle.png#deer.png#fish.png#gaiatreeprototypetree.png#oliveoil.png#rally.png#relics.png#repair.png#resource_food.png#resource_gold.png#resource_stone.png#resource_wood.png#sacred_sites.png#sheep.png#wolf.png',
+    'technology_abbasid':
+      'agriculture.png#armored-caravans.png#boot-camp.png#camel-handling.png#camel-rider-barding-4.png#camel-rider-shields.png#camel-support.png#composite-bows.png#faith.png#fertile-crescent-2.png#fresh-foodstuffs.png#grand-bazaar.png#improved-processing.png#medical-centers.png#phalanx.png#preservation-of-knowledge.png#public-library.png#spice-roads.png#teak-masts.png',
+    'technology_ayyubids':
+      'culture-wing-advancement-1.png#culture-wing-logistics-1.png#economic-wing-growth-1.png#economic-wing-industry-1.png#infantry-support-4.png#military-wing-master-smiths-1.png#military-wing-reinforcement-1.png#phalanx-2.png#siege-carpentry-3.png#sultans-mamluks-3.png#trade-wing-advisors-1.png#trade-wing-bazaar-1.png',
+    'technology_byzantines':
+      'border-settlements-2.png#eastern-mercenary-contract-1.png#elite-mercenaries-4.png#expilatores-2.png#ferocious-speed-4.png#greek-fire-projectiles-4.png#heavy-dromon-3.png#liquid-explosives-3.png#numeri-4.png#silk-road-mercenary-contract-1.png#teardrop-shields-3.png#trapezites-2.png#veteran-mercenaries-3.png#western-mercenary-contract-1.png',
+    'technology_chinese':
+      'ancient-techniques.png#battle-hardened.png#extra-hammocks.png#extra-materials.png#handcannon-slits.png#imperial-examination.png#pyrotechnics.png#reload-drills.png#reusable-barrels.png#thunderclap-bombs-4.png',
+    'technology_defensive':
+      'arrow-slits.png#boiling-oil.png#cannon-emplacement.png#court-architects.png#fortify-outpost.png#springald-emplacement.png',
+    'technology_delhi':
+      'all-seeing-eye.png#armored-beasts.png#efficient-production.png#forced-march.png#hearty-rations.png#honed-blades.png#lookout-towers.png#mahouts.png#manuscript-trade-1.png#paiks.png#reinforced-foundations.png#sanctity.png#siege-elephant.png#slow-burning-defenses.png#swiftness.png#tranquil-venue.png#village-fortresses.png#zeal.png',
+    'technology_dragon':
+      'bodkin-bolts-4.png#dragon-fire-2.png#dragon-scale-leather-3.png#golden-cuirass-2.png#war-horses-4.png#zornhau-3.png',
+    'technology_economy':
+      'acid-distilization.png#crosscut-saw.png#cupellation.png#double-broadaxe.png#drift-nets.png#extended-lines.png#fertilization.png#forestry.png#horticulture.png#lumber-preservation.png#precision-cross-breeding.png#professional-scouts.png#specialized-pick.png#survival-techniques.png#textiles.png#wheelbarrow.png',
+    'technology_english':
+      'admiralty-2.png#armor-clad.png#arrow-volley.png#enclosures.png#network-of-citadels.png#setup-camp.png#shattering-projectiles.png',
+    'technology_french':
+      'cantled-saddles.png#chivalry.png#crossbow-stirrups.png#enlistment-incentives.png#gambesons.png#long-guns.png#merchant-guilds-4.png#royal-bloodlines.png',
+    'technology_hre':
+      'benediction.png#devoutness.png#fire-stations.png#heavy-maces.png#inspired-warriors.png#marching-drills.png#reinforced-defenses.png#riveted-chain-mail-2.png#slate-and-stone-construction.png#steel-barding-3.png#two-handed-weapon.png',
+    'technology_japanese':
+      'bunrei.png#copper-plating-3.png#daimyo-manor-1.png#daimyo-palace-2.png#do-maru-armor-4.png#explosives-4.png#five_ministries.png#fudasashi-3.png#gion_festival.png#heated-shot-4.png#hizukuri-2.png#kabura-ya-whistling-arrow-3.png#kobuse-gitae-3.png#nagae-yari-4.png#nehan.png#oda-tactics-4.png#odachi-3.png#shinto_rituals.png#shogunate-castle-3.png#swivel-cannon-4.png#takezaiku-2.png#tatara-1.png#towara-1.png#yaki-ire-4.png#zen.png',
+    'technology_jeanne':
+      'companion-equipment-3.png#ordinance-company-3.png',
+    'technology_malians':
+      'banco-repairs-2.png#canoe-tactics-2.png#farima-leadership-4.png#imported-armor-3.png#local-knowledge-4.png#poisoned-arrows-3.png#precision-training-4.png',
+    'technology_military':
+      'angled-surfaces.png#balanced-projectiles.png#biology.png#bloomery.png#chemistry.png#damascus-steel.png#decarbonization.png#elite-army-tactics.png#fitted-leatherwork.png#geometry.png#greased-axles.png#incendiary-arrows.png#insulated-helm.png#iron-undermesh.png#master-smiths.png#military-academy.png#platecutter-point.png#siege-engineering.png#siege-works.png#steeled-arrow.png#wedge-rivets.png',
+    'technology_mongols':
+      'additional-torches.png#monastic-shrines.png#piracy.png#raid-bounty.png#siha-bow-limbs.png#steppe-lancers.png#stone-bounty.png#stone-commerce.png#superior-mobility.png#whistling-arrows.png#yam-network.png',
+    'technology_naval':
+      'additional-sails.png#armored-hull.png#chaser-cannons.png#explosives.png#extra-ballista.png#incendiaries-3.png#naval-arrow-slits.png#navigator-lookout.png#shipwrights-4.png#springald-crews-3.png',
+    'technology_ottomans':
+      'advanced-academy-1.png#anatolian-hills-1.png#fast-training-1.png#field-work-1.png#great-bombard-emplacement.png#imperial-fleet-4.png#janissary-company-1.png#janissary-guns-4.png#mehter-drums-1.png#military-campus-1.png#siege-crews-1.png#trade-bags-1.png',
+    'technology_religious': 'herbal-medicine.png#piety.png#tithe-barns.png',
+    'technology_rus':
+      'adaptable-hulls-3.png#banded-arms.png#blessing-duration.png#boyars-fortitude.png#castle-turret.png#castle-watch.png#cedar-hulls.png#clinker-construction.png#double-time.png#fine-tuned-guns.png#improved-blessing.png#knight-sabers.png#mounted-training.png#saints-reach.png#saints-veneration-4.png#siege-crew-training.png#wandering-town.png#warrior_scout_2.png',
+    'technology_units':
+      'adjustable-crossbars.png#lightweight-beams-4.png#roller-shutter-triggers.png#spyglass-4.png',
+    'technology_zhuxi':
+      '10000-bolts-4.png#advanced-administration-4.png#cloud-of-terror-4.png#dynastic-protectors-4.png#imperial-red-seals-3.png#military-affairs-bureau-1.png#roar-of-the-dragon-4.png',
+    'unit_abbasid':
+      'camel-archer-2.png#camel-rider-3.png#ghulam-3.png#imam.png',
+    'unit_ayyubids':
+      'atabeg-1.png#bedouin-skirmisher-2.png#bedouin-swordsman-1.png#camel-lancer-3.png#dervish-3.png#desert-raider-2.png#manjaniq-3.png#tower-of-the-sultan-3.png',
+    'unit_byzantines':
+      'arbaletrier-3.png#camel-archer-2.png#camel-rider-3.png#cataphract-3.png#cheirosiphon-3.png#desert-raider-2.png#dromon-2.png#ghulam-3.png#grenadier-4.png#horse-archer-3.png#javelin-thrower-2.png#keshik-2.png#landsknecht-3.png#limitanei-1.png#longbowman-2.png#mangudai.png#musofadi-warrior-2.png#royal-knight-2.png#sipahi-2.png#streltsy.png#tower-elephant-3.png#tower-of-the-sultan-3.png#varangian-guard-3.png#war-elephant.png#zhuge-nu-2.png',
+    'unit_cavalry':
+      'horseman-1.png#knight-2.png#lancer-3.png#lancer-4.png#scout.png',
+    'unit_chinese':
+      'fire-lancer-3.png#grenadier-4.png#imperial-official.png#junk.png#nest-of-bees.png#palace-guard-3.png#zhuge-nu-2.png',
+    'unit_delhi':
+      'ghazi-raider-2.png#scholar.png#sultans-elite-tower-elephant-4.png#tower-elephant-3.png#war-elephant.png',
+    'unit_dragon':
+      'dragon-handcannoneer-4.png#gilded-archer-2.png#gilded-crossbowman-3.png#gilded-horseman-2.png#gilded-knight-3.png#gilded-landsknecht-3.png#gilded-man-at-arms-2.png#gilded-spearman-1.png',
+    'unit_english':
+      'king-2.png#longbowman-2.png#wynguard-army-1.png#wynguard-footmen-1.png#wynguard-raiders-1.png#wynguard-ranger-4.png',
+    'unit_events': 'land_monster.png#water_monster.png',
+    'unit_french':
+      'arbaletrier-3.png#cannon-4.png#galleass.png#royal-cannon-4.png#royal-culverin-4.png#royal-knight-2.png#royal-ribauldequin-4.png#war-cog.png',
+    'unit_hre': 'landsknecht-3.png#prelate.png',
+    'unit_infantry':
+      'archer-2.png#crossbowman-3.png#handcannoneer-4.png#man-at-arms-1.png#spearman-1.png',
+    'unit_japanese':
+      'atakebune-4.png#buddhist-monk-3.png#katana-bannerman-2.png#mounted-samurai-3.png#onna-bugeisha-2.png#onna-musha-3.png#ozutsu-4.png#samurai-1.png#shinobi-2.png#shinto-priest-3.png#uma-bannerman-2.png#yumi-ashigaru-2.png#yumi-bannerman-2.png',
+    'unit_jeanne':
+      'jeanne-darc-blast-cannon-4.png#jeanne-darc-hunter-2.png#jeanne-darc-knight-3.png#jeanne-darc-markswoman-4.png#jeanne-darc-mounted-archer-3.png#jeanne-darc-peasant-1.png#jeanne-darc-woman-at-arms-2.png#jeannes-champion-3.png#jeannes-rider-3.png',
+    'unit_malians':
+      'donso-1.png#hunting-canoe-2.png#javelin-thrower-2.png#musofadi-gunner-4.png#musofadi-warrior-2.png#sofa-2.png#war-canoe-2.png#warrior-scout-2.png',
+    'unit_mongols':
+      'huihui-pao-1.png#keshik-2.png#khan-1.png#khans-hunter.png#light-junk.png#mangudai.png#shaman.png#traction-trebuchet.png',
+    'unit_ottomans':
+      'grand-galley-4.png#great-bombard-4.png#janissary-3.png#mehter-2.png#scout-ship-2.png#sipahi-2.png',
+    'unit_religious': 'imam-3.png#monk-3.png',
+    'unit_rus':
+      'horse-archer-3.png#lodya-attack-ship.png#lodya-demolition-ship.png#lodya-fishing-boat.png#lodya-galley-3.png#lodya-trade-ship.png#lodya-transport-ship.png#militia-2.png#streltsy.png#warrior-monk.png',
+    'unit_ship':
+      'baghlah.png#baochuan.png#carrack.png#demolition-ship.png#dhow.png#explosive-dhow.png#explosive-junk.png#fishing-boat.png#galley.png#hulk.png#junk-3.png#light-junk-2.png#trade-ship.png#transport-ship.png#war-junk.png#xebec.png',
+    'unit_siege':
+      'battering-ram.png#bombard.png#culverin-4.png#mangonel-3.png#ribauldequin-4.png#siege-tower.png#springald.png#trebuchet.png',
+    'unit_worker':
+      'monk-3.png#trader.png#villager-abbasid.png#villager-china.png#villager-delhi.png#villager-japanese.png#villager-malians.png#villager-mongols.png#villager-ottomans.png#villager.png',
+    'unit_zhuxi':
+      'imperial-guard-1.png#shaolin-monk-3.png#yuan-raider-4.png'
+  };
 
   // Split each string (e.g. 'image_0#image_1#image_2') in a list of images.
   for (const [key, value] of Object.entries(imagesDict)) {
@@ -4990,7 +5020,7 @@ function getInstructionsAoE4() {
     'On age4builder.com, select a build order, click on the salamander icon, and paste the content below.'
   ];
   return contentArrayToDiv(
-      getArrayInstructions(true, selectFactionLines, externalBOLines));
+    getArrayInstructions(true, selectFactionLines, externalBOLines));
 }
 
 /**
@@ -5006,7 +5036,7 @@ function openSinglePanelPageAoE4() {
   let columnsDescription = [
     new SinglePanelColumn('time', common + 'icon/time.png'),
     new SinglePanelColumn(
-        'population_count', game + 'building_economy/house.png'),
+      'population_count', game + 'building_economy/house.png'),
     new SinglePanelColumn('villager_count', game + 'unit_worker/villager.png'),
     new SinglePanelColumn('resources/builder', resource + 'repair.png'),
     new SinglePanelColumn('resources/food', resource + 'resource_food.png'),
@@ -5070,22 +5100,22 @@ function getResourceLineAoM(currentStep) {
   const resources = currentStep.resources;
 
   if (isBOImageValid(resources, 'food', true) ||
-      isBOImageValid(resources, 'wood', true) ||
-      isBOImageValid(resources, 'gold', true) ||
-      isBOImageValid(resources, 'favor', true)) {
+    isBOImageValid(resources, 'wood', true) ||
+    isBOImageValid(resources, 'gold', true) ||
+    isBOImageValid(resources, 'favor', true)) {
     htmlString +=
-        getBOImageValue(resourceFolder + 'food.png', resources, 'food');
+      getBOImageValue(resourceFolder + 'food.png', resources, 'food');
     htmlString +=
-        getBOImageValue(resourceFolder + 'wood.png', resources, 'wood');
+      getBOImageValue(resourceFolder + 'wood.png', resources, 'wood');
     htmlString +=
-        getBOImageValue(resourceFolder + 'gold.png', resources, 'gold');
+      getBOImageValue(resourceFolder + 'gold.png', resources, 'gold');
     htmlString +=
-        getBOImageValue(resourceFolder + 'favor.png', resources, 'favor');
+      getBOImageValue(resourceFolder + 'favor.png', resources, 'favor');
   }
   htmlString += getBOImageValue(
-      resourceFolder + 'repair.png', resources, 'builder', true);
+    resourceFolder + 'repair.png', resources, 'builder', true);
   htmlString += getBOImageValue(
-      resourceFolder + 'worker.png', currentStep, 'worker_count', true);
+    resourceFolder + 'worker.png', currentStep, 'worker_count', true);
 
   // Age image
   const ageImage = {
@@ -5098,7 +5128,7 @@ function getResourceLineAoM(currentStep) {
 
   if (currentStep.age in ageImage) {
     htmlString +=
-        getBOImageHTML(gamePicturesFolder + 'age/' + ageImage[currentStep.age]);
+      getBOImageHTML(gamePicturesFolder + 'age/' + ageImage[currentStep.age]);
   }
 
   return htmlString;
@@ -5124,7 +5154,7 @@ function checkValidBuildOrderAoM(nameBOMessage) {
 
     // Check correct major god
     const validFactionRes =
-        checkValidFaction(BONameStr, 'major_god', true, false);
+      checkValidFaction(BONameStr, 'major_god', true, false);
     if (!validFactionRes[0]) {
       return validFactionRes;
     }
@@ -5163,15 +5193,15 @@ function getBOStepAoM(builOrderData) {
       'worker_count': ('worker_count' in data) ? data['worker_count'] : 0,
       'age': ('age' in data) ? data['age'] : 1,
       'resources': ('resources' in data) ?
-          data['resources'] :
-          {'food': 0, 'wood': 0, 'gold': 0, 'favor': 0},
+        data['resources'] :
+        { 'food': 0, 'wood': 0, 'gold': 0, 'favor': 0 },
       'notes': ['Note 1', 'Note 2']
     };
   } else {
     return {
       'worker_count': 0,
       'age': 1,
-      'resources': {'food': 0, 'wood': 0, 'gold': 0, 'favor': 0},
+      'resources': { 'food': 0, 'wood': 0, 'gold': 0, 'favor': 0 },
       'notes': ['Note 1', 'Note 2']
     };
   }
@@ -5263,7 +5293,7 @@ function evaluateBOTimingAoM(timeOffset) {
   if (Array.isArray(majorGodData)) {
     if (!majorGodData.length) {
       console.log(
-          'Warning: the array of \'major_god\' is empty, timing cannot be evaluated.')
+        'Warning: the array of \'major_god\' is empty, timing cannot be evaluated.')
       return;
     }
     pantheon = getPantheon(majorGodData[0]);
@@ -5297,7 +5327,7 @@ function evaluateBOTimingAoM(timeOffset) {
 
   if (!('build_order' in dataBO)) {
     console.log(
-        'Warning: the \'build_order\' field is missing from data when evaluating the timing.')
+      'Warning: the \'build_order\' field is missing from data when evaluating the timing.')
     return;
   }
 
@@ -5315,7 +5345,7 @@ function evaluateBOTimingAoM(timeOffset) {
     const resources = currentStep['resources'];
     if (workerCount < 0) {
       workerCount = Math.max(0, resources['wood']) +
-          Math.max(0, resources['food']) + Math.max(0, resources['gold']);
+        Math.max(0, resources['food']) + Math.max(0, resources['gold']);
       if (pantheon === 'Greeks') {  // Only Greeks villagers can gather favor
         workerCount += Math.max(0, resources['favor']);
       }
@@ -5334,7 +5364,7 @@ function evaluateBOTimingAoM(timeOffset) {
     // Check for TC technologies or special units in notes
     for (note of currentStep['notes']) {
       for (const [tcItemImage, tcItemTime] of Object.entries(
-               TCUnitTechnologies)) {
+        TCUnitTechnologies)) {
         if (note.includes('@' + tcItemImage + '@')) {
           stepTotalTime += tcItemTime;
         }
@@ -5343,8 +5373,8 @@ function evaluateBOTimingAoM(timeOffset) {
 
     // Next age
     const nextAge = (1 <= currentStep['age'] && currentStep['age'] <= 5) ?
-        currentStep['age'] :
-        currentAge;
+      currentStep['age'] :
+      currentAge;
     if (nextAge === currentAge + 1)  // researching next age up
     {
       stepTotalTime += getResearchAgeUpTimeAoM(currentAge);
@@ -5360,7 +5390,7 @@ function evaluateBOTimingAoM(timeOffset) {
     // Special case for last step
     // (add 1 sec to avoid displaying both at the same time).
     if ((currentStepID === stepCount - 1) && (stepCount >= 2) &&
-        (currentStep['time'] === buildOrderData[currentStepID - 1]['time'])) {
+      (currentStep['time'] === buildOrderData[currentStepID - 1]['time'])) {
       currentStep['time'] = buildOrderTimeToStr(Math.round(lastTimeSec + 1.0));
     }
   }
@@ -5374,101 +5404,101 @@ function evaluateBOTimingAoM(timeOffset) {
 function getImagesAoM() {
   // This is obtained using the 'python/utilities/list_images.py' script.
   const imagesDict =
-      {
-        'age':
-            'archaic_age.png#classical_age.png#heroic_age.png#mythic_age.png#wonder_age.png',
-        'animal':
-            'arctic_wolf.png#aurochs.png#baboon.png#bear.png#boar.png#caribou.png#chicken.png#cow.png#crocodile.png#crowned_crane.png#deer.png#elephant.png#elk.png#fish.png#gazelle.png#giraffe.png#goat.png#hippopotamus.png#hyena.png#lion.png#monkey.png#pig.png#polar_bear.png#rhinoceros.png#tiger.png#walrus.png#water_buffalo.png#wolf.png#zebra.png',
-        'armory':
-            'armory.png#ballistics.png#bronze_armor.png#bronze_shields.png#bronze_weapons.png#burning_pitch.png#copper_armor.png#copper_shields.png#copper_weapons.png#iron_armor.png#iron_shields.png#iron_weapons.png',
-        'atlanteans_building':
-            'counter-barracks.png#economic_guild.png#manor.png#military_barracks.png#mirror_tower.png#palace.png#sky_passage.png#time_shift.png#town_center_atlantean.png',
-        'atlanteans_civilian': 'caravan_atlantean.png#citizen.png',
-        'atlanteans_hero':
-            'arcus_hero.png#cheiroballista_hero.png#citizen_hero.png#contarius_hero.png#destroyer_hero.png#fanatic_hero.png#katapeltes_hero.png#murmillo_hero.png#oracle_hero.png#turma_hero.png',
-        'atlanteans_human':
-            'arcus.png#contarius.png#destroyer.png#fanatic.png#katapeltes.png#murmillo.png#oracle_unit.png#turma.png',
-        'atlanteans_minor_god':
-            'atlas.png#hekate.png#helios.png#hyperion.png#leto.png#oceanus.png#prometheus.png#rheia.png#theia.png',
-        'atlanteans_myth':
-            'argus.png#atlantean_titan.png#automaton.png#behemoth.png#caladria.png#centimanus.png#lampades.png#man_o_war.png#nereid.png#promethean.png#satyr.png#servant.png#stymphalian_bird.png',
-        'atlanteans_power':
-            'carnivora_power.png#chaos.png#deconstruction.png#gaia_forest.png#hesperides.png#implode.png#shockwave.png#spider_lair.png#tartarian_gate_power.png#traitor.png#valor.png#vortex.png',
-        'atlanteans_ship':
-            'bireme.png#fire_ship.png#fishing_ship_atlantean.png#siege_bireme.png#transport_ship_atlantean.png',
-        'atlanteans_siege': 'cheiroballista.png#fire_siphon.png',
-        'atlanteans_tech':
-            'alluvial_clay.png#asper_blood.png#bite_of_the_shark.png#celerity.png#channels.png#conscript_counter_soldiers.png#conscript_mainline_soldiers.png#conscript_palace_soldiers.png#empyrian_speed.png#eyes_of_atlas.png#focus.png#gemini.png#guardian_of_io.png#halo_of_the_sun.png#heart_of_the_titans.png#hephaestus_revenge.png#heroic_renewal.png#horns_of_consecration.png#lance_of_stone.png#lemuriandescendants.png#levy_counter_soldiers.png#levy_mainline_soldiers.png#levy_palace_soldiers.png#mythic_rejuvenation.png#orichalcum_mail.png#petrification.png#poseidons_secret.png#rheias_gift.png#safe_passage.png#temporal_chaos.png#titan_shield.png#volcanic_forge.png#weightless_mace.png',
-        'defensive':
-            'boiling_oil.png#bronze_wall.png#carrier_pigeons.png#citadel_wall.png#crenellations.png#fortified_wall.png#guard_tower_upgrade.png#improvement_ballista_tower.png#improvement_watch_tower.png#iron_wall.png#orichalkos_wall.png#sentry_tower.png#signal_fires.png#stone_wall.png#wooden_wall.png',
-        'dock':
-            'arrowship_cladding.png#champion_warships.png#conscript_sailors.png#dock.png#enclosed_deck.png#heavy_warships.png#heroic_fleet.png#naval_oxybeles.png#purse_seine.png#reinforced_ram.png#salt_amphora.png',
-        'economy':
-            'bow_saw.png#carpenters.png#flood_control.png#hand_axe.png#husbandry.png#irrigation.png#pickaxe.png#plow.png#quarry.png#shaft_mine.png#survival_equipment.png',
-        'egyptians_building':
-            'barracks.png#granary.png#lighthouse.png#lumber_camp.png#migdol_stronghold.png#mining_camp.png#monument_to_villagers.png#obelisk.png#siege_works.png#town_center_egyptian.png',
-        'egyptians_civilian': 'caravan_egyptian.png#laborer.png',
-        'egyptians_hero': 'pharaoh.png#priest.png',
-        'egyptians_human': 'axeman.png#camel_rider.png#chariot_archer.png#mercenary.png#mercenary_cavalry.png#slinger.png#spearman.png#war_elephant.png',
-        'egyptians_minor_god':
-            'anubis.png#bast.png#horus.png#nephthys.png#osiris.png#ptah.png#sekhmet.png#sobek.png#thoth.png',
-        'egyptians_myth':
-            'anubite.png#avenger.png#egyptian_titan.png#leviathan.png#mummy.png#petsuchos.png#phoenix.png#roc.png#scarab.png#scorpion_man.png#son_of_osiris.png#sphinx.png#wadjet.png#war_turtle.png',
-        'egyptians_power':
-            'ancestors.png#citadel_power.png#eclipse.png#locust_swarm.png#meteor.png#plague_of_serpents.png#prosperity.png#rain.png#shifting_sands.png#son_of_osiris_power.png#tornado.png#vision.png',
-        'egyptians_ship':
-            'fishing_ship_egyptian.png#kebenit.png#ramming_galley.png#transport_ship_egyptian.png#war_barge.png',
-        'egyptians_siege': 'catapult.png#siege_tower.png',
-        'egyptians_tech':
-            'adze_of_wepwawet.png#atef_crown.png#axe_of_vengeance.png#bone_bow.png#book_of_thoth.png#champion_axemen.png#champion_camel_riders.png#champion_chariot_archers.png#champion_slingers.png#champion_spearmen.png#champion_war_elephants.png#clairvoyance.png#conscript_barracks_soldiers.png#conscript_migdol_soldiers.png#crimson_linen.png#criosphinx.png#crocodilopolis.png#dark_water.png#desert_wind.png#electrum_bullets.png#feet_of_the_jackal.png#feral.png#flood_of_the_nile.png#force_of_the_west_wind.png#funeral_barge.png#funeral_rites.png#greatest_of_fifty.png#hands_of_the_pharaoh.png#heavy_axemen.png#heavy_camel_riders.png#heavy_chariot_archers.png#heavy_slingers.png#heavy_spearmen.png#heavy_war_elephants.png#hieracosphinx.png#leather_frame_shield.png#levy_barracks_soldiers.png#levy_migdol_soldiers.png#medium_axemen.png#medium_slingers.png#medium_spearmen.png#nebty.png#necropolis.png#new_kingdom.png#sacred_cats.png#scalloped_axe.png#serpent_spear.png#shaduf.png#skin_of_the_rhino.png#slings_of_the_sun.png#solar_barque - copy.png#solar_barque.png#spear_of_horus.png#spirit_of_maat.png#stones_of_red_linen.png#sundried_mud_brick.png#tusks_of_apedemak.png#valley_of_the_kings.png#city_of_the_dead.jpg',
-        'greeks_building':
-            'archery_range.png#fortress.png#granary.png#military_academy.png#stable.png#storehouse.png#town_center_greek.png#village_center_greeks.png',
-        'greeks_civilian': 'caravan_greek.png#villager_greek.png',
-        'greeks_hero':
-            'achilles.png#ajax_spc.png#atalanta.png#bellerophon.png#chiron.png#heracles.png#hippolyta.png#jason.png#odysseus.png#perseus.png#polyphemus.png#theseus.png',
-        'greeks_human':
-            'gastraphetoros.png#hetairos.png#hippeus.png#hoplite.png#hypaspist.png#militia.png#myrmidon.png#peltast.png#prodromos.png#toxotes.png',
-        'greeks_minor_god':
-            'aphrodite.png#apollo.png#ares.png#artemis.png#athena.png#dionysus.png#hephaestus.png#hera.png#hermes.png',
-        'greeks_myth':
-            'carcinos.png#centaur.png#chimera.png#colossus.png#cyclops.png#greek_titan.png#hippocampus.png#hydra.png#manticore.png#medusa.png#minotaur.png#nemean_lion.png#pegasus.png#scylla.png',
-        'greeks_power':
-            'bolt.png#bronze.png#ceasefire.png#curse.png#earthquake.png#lightning_storm.png#lure_power.png#pestilence.png#plenty_vault.png#restoration.png#sentinel_power.png#underworld_passage.png',
-        'greeks_ship':
-            'fishing_ship_greek.png#juggernaut.png#pentekonter.png#transport_ship_greek.png#trireme.png',
-        'greeks_siege': 'helepolis.png#petrobolos.png',
-        'greeks_tech':
-            'aegis_shield.png#anastrophe.png#argive_patronage.png#conscript_cavalry.png#conscript_infantry.png#conscript_ranged_soldiers.png#deimos_sword_of_dread.png#dionysia.png#divine_blood.png#enyos_bow_of_horror.png#face_of_the_gorgon.png#flames_of_typhon.png#forge_of_olympus.png#golden_apples.png#hand_of_talos.png#labyrinth_of_minos.png#levy_cavalry.png#levy_infantry.png#levy_ranged_soldiers.png#lord_of_horses.png#monstrous_rage.png#olympian_parentage.png#olympian_weapons.png#oracle.png#phobos_spear_of_panic.png#roar_of_orthus.png#sarissa.png#shafts_of_plague.png#shoulder_of_talos.png#spirited_charge.png#sun_ray.png#sylvan_lore.png#temple_of_healing.png#thracian_horses.png#trierarch.png#vaults_of_erebus.png#will_of_kronos.png#winged_messenger.png',
-        'major_god':
-            'freyr.png#gaia.png#hades.png#isis.png#kronos.png#loki.png#odin.png#oranos.png#poseidon.png#ra.png#set.png#thor.png#zeus.png',
-        'market': 'ambassadors.png#coinage.png#market.png#tax_collectors.png',
-        'norse_building':
-            'dwarven_armory.png#great_hall.png#hill_fort.png#longhouse.png#town_center_norse.png',
-        'norse_civilian':
-            'caravan_norse.png#dwarf.png#gatherer.png#ox_cart.png',
-        'norse_hero': 'godi.png#hersir.png',
-        'norse_human':
-            'berserk.png#hirdman.png#huskarl.png#jarl.png#raiding_cavalry.png#throwing_axeman.png',
-        'norse_minor_god':
-            'aegir.png#baldr.png#bragi.png#forseti.png#freyja.png#heimdall.png#hel.png#njord.png#skadi.png#tyr.png#ullr.png#vidar.png',
-        'norse_myth':
-            'battle_boar.png#draugr.png#einherjar.png#fafnir.png#fenris_wolf_brood.png#fimbulwinter_wolf.png#fire_giant.png#frost_giant.png#jormun_elver.png#kraken.png#mountain_giant.png#nidhogg_unit.png#norse_titan.png#raven.png#rock_giant.png#troll.png#valkyrie.png#walking_woods_unit.png',
-        'norse_power':
-            'asgardian_bastion.png#dwarven_mine.png#fimbulwinter.png#flaming_weapons.png#forest_fire.png#frost.png#great_hunt.png#gullinbursti.png#healing_spring_power.png#inferno.png#nidhogg.png#ragnarok.png#spy.png#tempest.png#undermine.png#walking_woods_power.png',
-        'norse_ship':
-            'dragon_ship.png#dreki.png#fishing_ship_norse.png#longboat.png#transport_ship_norse.png',
-        'norse_siege': 'ballista.png#portable_ram.png',
-        'norse_tech':
-            'arctic_winds.png#avenging_spirit.png#berserkergang.png#bravery.png#call_of_valhalla.png#cave_troll.png#conscript_great_hall_soldiers.png#conscript_hill_fort_soldiers.png#conscript_longhouse_soldiers.png#disablot.png#dragonscale_shields.png#dwarven_auger.png#dwarven_breastplate.png#dwarven_weapons.png#eyes_in_the_forest.png#feasts_of_renown.png#freyr\'s_gift.png#fury_of_the_fallen.png#gjallarhorn.png#granite_blood.png#granite_maw.png#grasp_of_ran.png#hall_of_thanes.png#hamask.png#hammer_of_thunder.png#huntress_axe.png#levy_great_hall_soldiers.png#levy_hill_fort_soldiers.png#levy_longhouse_soldiers.png#long_serpent.png#meteoric_iron_armor.png#nine_waves.png#rampage.png#rime.png#ring_giver.png#ring_oath.png#safeguard.png#servants_of_glory.png#sessrumnir.png#silent_resolve.png#sons_of_sleipnir.png#swine_array.png#thundering_hooves.png#thurisaz_rune.png#twilight_of_the_gods.png#valgaldr.png#winter_harvest.png#wrath_of_the_deep.png#ydalir.png',
-        'other': 'farm.png#house.png#relic.png#titan_gate.png#wonder.png',
-        'resource':
-            'berry.png#favor.png#food.png#gold.png#repair.png#tree.png#wood.png#worker.png',
-        'tech_military':
-            'champion_archers.png#champion_cavalry.png#champion_infantry.png#draft_horses.png#engineers.png#heavy_archers.png#heavy_cavalry.png#heavy_infantry.png#medium_archers.png#medium_cavalry.png#medium_infantry.png#norse_champion_infantry.png#norse_heavy_infantry.png#norse_medium_infantry.png',
-        'temple': 'omniscience.png#temple.png',
-        'town_center':
-            'architects.png#fortified_town_center.png#masons.png#town_center.png#village_center.png'
-      };
+  {
+    'age':
+      'archaic_age.png#classical_age.png#heroic_age.png#mythic_age.png#wonder_age.png',
+    'animal':
+      'arctic_wolf.png#aurochs.png#baboon.png#bear.png#boar.png#caribou.png#chicken.png#cow.png#crocodile.png#crowned_crane.png#deer.png#elephant.png#elk.png#fish.png#gazelle.png#giraffe.png#goat.png#hippopotamus.png#hyena.png#lion.png#monkey.png#pig.png#polar_bear.png#rhinoceros.png#tiger.png#walrus.png#water_buffalo.png#wolf.png#zebra.png',
+    'armory':
+      'armory.png#ballistics.png#bronze_armor.png#bronze_shields.png#bronze_weapons.png#burning_pitch.png#copper_armor.png#copper_shields.png#copper_weapons.png#iron_armor.png#iron_shields.png#iron_weapons.png',
+    'atlanteans_building':
+      'counter-barracks.png#economic_guild.png#manor.png#military_barracks.png#mirror_tower.png#palace.png#sky_passage.png#time_shift.png#town_center_atlantean.png',
+    'atlanteans_civilian': 'caravan_atlantean.png#citizen.png',
+    'atlanteans_hero':
+      'arcus_hero.png#cheiroballista_hero.png#citizen_hero.png#contarius_hero.png#destroyer_hero.png#fanatic_hero.png#katapeltes_hero.png#murmillo_hero.png#oracle_hero.png#turma_hero.png',
+    'atlanteans_human':
+      'arcus.png#contarius.png#destroyer.png#fanatic.png#katapeltes.png#murmillo.png#oracle_unit.png#turma.png',
+    'atlanteans_minor_god':
+      'atlas.png#hekate.png#helios.png#hyperion.png#leto.png#oceanus.png#prometheus.png#rheia.png#theia.png',
+    'atlanteans_myth':
+      'argus.png#atlantean_titan.png#automaton.png#behemoth.png#caladria.png#centimanus.png#lampades.png#man_o_war.png#nereid.png#promethean.png#satyr.png#servant.png#stymphalian_bird.png',
+    'atlanteans_power':
+      'carnivora_power.png#chaos.png#deconstruction.png#gaia_forest.png#hesperides.png#implode.png#shockwave.png#spider_lair.png#tartarian_gate_power.png#traitor.png#valor.png#vortex.png',
+    'atlanteans_ship':
+      'bireme.png#fire_ship.png#fishing_ship_atlantean.png#siege_bireme.png#transport_ship_atlantean.png',
+    'atlanteans_siege': 'cheiroballista.png#fire_siphon.png',
+    'atlanteans_tech':
+      'alluvial_clay.png#asper_blood.png#bite_of_the_shark.png#celerity.png#channels.png#conscript_counter_soldiers.png#conscript_mainline_soldiers.png#conscript_palace_soldiers.png#empyrian_speed.png#eyes_of_atlas.png#focus.png#gemini.png#guardian_of_io.png#halo_of_the_sun.png#heart_of_the_titans.png#hephaestus_revenge.png#heroic_renewal.png#horns_of_consecration.png#lance_of_stone.png#lemuriandescendants.png#levy_counter_soldiers.png#levy_mainline_soldiers.png#levy_palace_soldiers.png#mythic_rejuvenation.png#orichalcum_mail.png#petrification.png#poseidons_secret.png#rheias_gift.png#safe_passage.png#temporal_chaos.png#titan_shield.png#volcanic_forge.png#weightless_mace.png',
+    'defensive':
+      'boiling_oil.png#bronze_wall.png#carrier_pigeons.png#citadel_wall.png#crenellations.png#fortified_wall.png#guard_tower_upgrade.png#improvement_ballista_tower.png#improvement_watch_tower.png#iron_wall.png#orichalkos_wall.png#sentry_tower.png#signal_fires.png#stone_wall.png#wooden_wall.png',
+    'dock':
+      'arrowship_cladding.png#champion_warships.png#conscript_sailors.png#dock.png#enclosed_deck.png#heavy_warships.png#heroic_fleet.png#naval_oxybeles.png#purse_seine.png#reinforced_ram.png#salt_amphora.png',
+    'economy':
+      'bow_saw.png#carpenters.png#flood_control.png#hand_axe.png#husbandry.png#irrigation.png#pickaxe.png#plow.png#quarry.png#shaft_mine.png#survival_equipment.png',
+    'egyptians_building':
+      'barracks.png#granary.png#lighthouse.png#lumber_camp.png#migdol_stronghold.png#mining_camp.png#monument_to_villagers.png#obelisk.png#siege_works.png#town_center_egyptian.png',
+    'egyptians_civilian': 'caravan_egyptian.png#laborer.png',
+    'egyptians_hero': 'pharaoh.png#priest.png',
+    'egyptians_human': 'axeman.png#camel_rider.png#chariot_archer.png#mercenary.png#mercenary_cavalry.png#slinger.png#spearman.png#war_elephant.png',
+    'egyptians_minor_god':
+      'anubis.png#bast.png#horus.png#nephthys.png#osiris.png#ptah.png#sekhmet.png#sobek.png#thoth.png',
+    'egyptians_myth':
+      'anubite.png#avenger.png#egyptian_titan.png#leviathan.png#mummy.png#petsuchos.png#phoenix.png#roc.png#scarab.png#scorpion_man.png#son_of_osiris.png#sphinx.png#wadjet.png#war_turtle.png',
+    'egyptians_power':
+      'ancestors.png#citadel_power.png#eclipse.png#locust_swarm.png#meteor.png#plague_of_serpents.png#prosperity.png#rain.png#shifting_sands.png#son_of_osiris_power.png#tornado.png#vision.png',
+    'egyptians_ship':
+      'fishing_ship_egyptian.png#kebenit.png#ramming_galley.png#transport_ship_egyptian.png#war_barge.png',
+    'egyptians_siege': 'catapult.png#siege_tower.png',
+    'egyptians_tech':
+      'adze_of_wepwawet.png#atef_crown.png#axe_of_vengeance.png#bone_bow.png#book_of_thoth.png#champion_axemen.png#champion_camel_riders.png#champion_chariot_archers.png#champion_slingers.png#champion_spearmen.png#champion_war_elephants.png#clairvoyance.png#conscript_barracks_soldiers.png#conscript_migdol_soldiers.png#crimson_linen.png#criosphinx.png#crocodilopolis.png#dark_water.png#desert_wind.png#electrum_bullets.png#feet_of_the_jackal.png#feral.png#flood_of_the_nile.png#force_of_the_west_wind.png#funeral_barge.png#funeral_rites.png#greatest_of_fifty.png#hands_of_the_pharaoh.png#heavy_axemen.png#heavy_camel_riders.png#heavy_chariot_archers.png#heavy_slingers.png#heavy_spearmen.png#heavy_war_elephants.png#hieracosphinx.png#leather_frame_shield.png#levy_barracks_soldiers.png#levy_migdol_soldiers.png#medium_axemen.png#medium_slingers.png#medium_spearmen.png#nebty.png#necropolis.png#new_kingdom.png#sacred_cats.png#scalloped_axe.png#serpent_spear.png#shaduf.png#skin_of_the_rhino.png#slings_of_the_sun.png#solar_barque - copy.png#solar_barque.png#spear_of_horus.png#spirit_of_maat.png#stones_of_red_linen.png#sundried_mud_brick.png#tusks_of_apedemak.png#valley_of_the_kings.png#city_of_the_dead.jpg',
+    'greeks_building':
+      'archery_range.png#fortress.png#granary.png#military_academy.png#stable.png#storehouse.png#town_center_greek.png#village_center_greeks.png',
+    'greeks_civilian': 'caravan_greek.png#villager_greek.png',
+    'greeks_hero':
+      'achilles.png#ajax_spc.png#atalanta.png#bellerophon.png#chiron.png#heracles.png#hippolyta.png#jason.png#odysseus.png#perseus.png#polyphemus.png#theseus.png',
+    'greeks_human':
+      'gastraphetoros.png#hetairos.png#hippeus.png#hoplite.png#hypaspist.png#militia.png#myrmidon.png#peltast.png#prodromos.png#toxotes.png',
+    'greeks_minor_god':
+      'aphrodite.png#apollo.png#ares.png#artemis.png#athena.png#dionysus.png#hephaestus.png#hera.png#hermes.png',
+    'greeks_myth':
+      'carcinos.png#centaur.png#chimera.png#colossus.png#cyclops.png#greek_titan.png#hippocampus.png#hydra.png#manticore.png#medusa.png#minotaur.png#nemean_lion.png#pegasus.png#scylla.png',
+    'greeks_power':
+      'bolt.png#bronze.png#ceasefire.png#curse.png#earthquake.png#lightning_storm.png#lure_power.png#pestilence.png#plenty_vault.png#restoration.png#sentinel_power.png#underworld_passage.png',
+    'greeks_ship':
+      'fishing_ship_greek.png#juggernaut.png#pentekonter.png#transport_ship_greek.png#trireme.png',
+    'greeks_siege': 'helepolis.png#petrobolos.png',
+    'greeks_tech':
+      'aegis_shield.png#anastrophe.png#argive_patronage.png#conscript_cavalry.png#conscript_infantry.png#conscript_ranged_soldiers.png#deimos_sword_of_dread.png#dionysia.png#divine_blood.png#enyos_bow_of_horror.png#face_of_the_gorgon.png#flames_of_typhon.png#forge_of_olympus.png#golden_apples.png#hand_of_talos.png#labyrinth_of_minos.png#levy_cavalry.png#levy_infantry.png#levy_ranged_soldiers.png#lord_of_horses.png#monstrous_rage.png#olympian_parentage.png#olympian_weapons.png#oracle.png#phobos_spear_of_panic.png#roar_of_orthus.png#sarissa.png#shafts_of_plague.png#shoulder_of_talos.png#spirited_charge.png#sun_ray.png#sylvan_lore.png#temple_of_healing.png#thracian_horses.png#trierarch.png#vaults_of_erebus.png#will_of_kronos.png#winged_messenger.png',
+    'major_god':
+      'freyr.png#gaia.png#hades.png#isis.png#kronos.png#loki.png#odin.png#oranos.png#poseidon.png#ra.png#set.png#thor.png#zeus.png',
+    'market': 'ambassadors.png#coinage.png#market.png#tax_collectors.png',
+    'norse_building':
+      'dwarven_armory.png#great_hall.png#hill_fort.png#longhouse.png#town_center_norse.png',
+    'norse_civilian':
+      'caravan_norse.png#dwarf.png#gatherer.png#ox_cart.png',
+    'norse_hero': 'godi.png#hersir.png',
+    'norse_human':
+      'berserk.png#hirdman.png#huskarl.png#jarl.png#raiding_cavalry.png#throwing_axeman.png',
+    'norse_minor_god':
+      'aegir.png#baldr.png#bragi.png#forseti.png#freyja.png#heimdall.png#hel.png#njord.png#skadi.png#tyr.png#ullr.png#vidar.png',
+    'norse_myth':
+      'battle_boar.png#draugr.png#einherjar.png#fafnir.png#fenris_wolf_brood.png#fimbulwinter_wolf.png#fire_giant.png#frost_giant.png#jormun_elver.png#kraken.png#mountain_giant.png#nidhogg_unit.png#norse_titan.png#raven.png#rock_giant.png#troll.png#valkyrie.png#walking_woods_unit.png',
+    'norse_power':
+      'asgardian_bastion.png#dwarven_mine.png#fimbulwinter.png#flaming_weapons.png#forest_fire.png#frost.png#great_hunt.png#gullinbursti.png#healing_spring_power.png#inferno.png#nidhogg.png#ragnarok.png#spy.png#tempest.png#undermine.png#walking_woods_power.png',
+    'norse_ship':
+      'dragon_ship.png#dreki.png#fishing_ship_norse.png#longboat.png#transport_ship_norse.png',
+    'norse_siege': 'ballista.png#portable_ram.png',
+    'norse_tech':
+      'arctic_winds.png#avenging_spirit.png#berserkergang.png#bravery.png#call_of_valhalla.png#cave_troll.png#conscript_great_hall_soldiers.png#conscript_hill_fort_soldiers.png#conscript_longhouse_soldiers.png#disablot.png#dragonscale_shields.png#dwarven_auger.png#dwarven_breastplate.png#dwarven_weapons.png#eyes_in_the_forest.png#feasts_of_renown.png#freyr\'s_gift.png#fury_of_the_fallen.png#gjallarhorn.png#granite_blood.png#granite_maw.png#grasp_of_ran.png#hall_of_thanes.png#hamask.png#hammer_of_thunder.png#huntress_axe.png#levy_great_hall_soldiers.png#levy_hill_fort_soldiers.png#levy_longhouse_soldiers.png#long_serpent.png#meteoric_iron_armor.png#nine_waves.png#rampage.png#rime.png#ring_giver.png#ring_oath.png#safeguard.png#servants_of_glory.png#sessrumnir.png#silent_resolve.png#sons_of_sleipnir.png#swine_array.png#thundering_hooves.png#thurisaz_rune.png#twilight_of_the_gods.png#valgaldr.png#winter_harvest.png#wrath_of_the_deep.png#ydalir.png',
+    'other': 'farm.png#house.png#relic.png#titan_gate.png#wonder.png',
+    'resource':
+      'berry.png#favor.png#food.png#gold.png#repair.png#tree.png#wood.png#worker.png',
+    'tech_military':
+      'champion_archers.png#champion_cavalry.png#champion_infantry.png#draft_horses.png#engineers.png#heavy_archers.png#heavy_cavalry.png#heavy_infantry.png#medium_archers.png#medium_cavalry.png#medium_infantry.png#norse_champion_infantry.png#norse_heavy_infantry.png#norse_medium_infantry.png',
+    'temple': 'omniscience.png#temple.png',
+    'town_center':
+      'architects.png#fortified_town_center.png#masons.png#town_center.png#village_center.png'
+  };
 
   // Split each string (e.g. 'image_0#image_1#image_2') in a list of images.
   for (const [key, value] of Object.entries(imagesDict)) {
@@ -5606,11 +5636,11 @@ function getResourceLineSC2(currentStep) {
   const resourceFolder = gamePicturesFolder + 'resource/';
 
   htmlString += getBOImageValue(
-      resourceFolder + 'minerals.png', currentStep, 'minerals', true);
+    resourceFolder + 'minerals.png', currentStep, 'minerals', true);
   htmlString += getBOImageValue(
-      resourceFolder + 'vespene_gas.png', currentStep, 'vespene_gas', true);
+    resourceFolder + 'vespene_gas.png', currentStep, 'vespene_gas', true);
   htmlString += getBOImageValue(
-      commonPicturesFolder + 'icon/house.png', currentStep, 'supply', true);
+    commonPicturesFolder + 'icon/house.png', currentStep, 'supply', true);
 
   return htmlString;
 }
@@ -5640,7 +5670,7 @@ function checkValidBuildOrderSC2(nameBOMessage) {
     }
 
     const validOpponentRaceRes =
-        checkValidFaction(BONameStr, 'opponent_race', true);
+      checkValidFaction(BONameStr, 'opponent_race', true);
     if (!validOpponentRaceRes[0]) {
       return validOpponentRaceRes;
     }
@@ -5714,30 +5744,30 @@ function getBOTemplateSC2() {
 function getImagesSC2() {
   // This is obtained using the 'python/utilities/list_images.py' script.
   const
-      imagesDict =
-          {
-            'protoss_buildings':
-                'Assimilator.png#Cybernetics_Core.png#Dark_Shrine.png#Fleet_Beacon.png#Forge.png#Gateway.png#Nexus.png#Photon_Cannon.png#Pylon.png#Robotics_Bay.png#Robotics_Facility.png#ShieldBattery.png#Stargate.png#StasisWard.png#Templar_Archives.png#Twilight_Council.png#Warp_Gate.png',
-            'protoss_techs':
-                'Air_armor_1.png#Air_armor_2.png#Air_armor_3.png#Air_weapons_1.png#Air_weapons_2.png#Air_weapons_3.png#Anion_Pulse-Crystals.png#Battery_Overcharge.png#Blink.png#Charge.png#Chrono_boost.png#Extended_thermal_lances.png#Flux_Vanes.png#Gravitic_booster.png#Gravitic_drive.png#Graviton_catapult.png#Ground_armor_1.png#Ground_armor_2.png#Ground_armor_3.png#Ground_weapons_1.png#Ground_weapons_2.png#Ground_weapons_3.png#Guardian_shield.png#Mass_Recall.png#Psionic_storm.png#Resonating_Glaives.png#Shadow_Stride.png#Shields_1.png#Shields_2.png#Shields_3.png#Tectonic_Destabilizers.png#Transform_warpgate.png',
-            'protoss_units':
-                'Adept.png#Archon.png#Carrier.png#Colossus.png#Dark_Templar.png#Disruptor.png#High_Templar.png#Immortal.png#Mothership.png#Mothership_Core.png#Observer.png#Oracle.png#Phoenix.png#Probe.png#Sentry.png#Stalker.png#Tempest.png#VoidRay.png#Warp_Prism.png#Zealot.png',
-            'race_icon':
-                'AnyRaceIcon.png#ProtossIcon.png#TerranIcon.png#ZergIcon.png',
-            'resource': 'minerals.png#vespene_gas.png',
-            'terran_buildings':
-                'Armory.png#Barracks.png#Bunker.png#CommandCenter.png#EngineeringBay.png#Factory.png#FusionCore.png#GhostAcademy.png#MissileTurret.png#OrbitalCommand.png#PlanetaryFortress.png#Reactor.png#Refinery.png#SensorTower.png#Starport.png#SupplyDepot.png#TechLab.png',
-            'terran_techs':
-                'Advanced_Ballistics.png#Behemoth_reactor.png#Building_armor.png#Build_Reactor.png#Build_Tech_Lab.png#Calldown_extra_supplies.png#Calldown_mule.png#Cloak.png#Enhanced_Shockwaves.png#High_Capacity_Fuel_Tanks.png#Hisec_auto_tracking.png#Infantry_armor_1.png#Infantry_armor_2.png#Infantry_armor_3.png#Infantry_weapons_1.png#Infantry_weapons_2.png#Infantry_weapons_3.png#Lower.png#Moebius_reactor.png#Neosteel_frames.png#Nuke.png#Scanner_sweep.png#Ship_weapons_1.png#Ship_weapons_2.png#Ship_weapons_3.png#Vehicle_plating_1.png#Vehicle_plating_2.png#Vehicle_plating_3.png#Vehicle_weapons_1.png#Vehicle_weapons_2.png#Vehicle_weapons_3.png#Yamato_cannon.png',
-            'terran_units':
-                'Auto-turret.png#Banshee.png#Battlecruiser.png#Cyclone.png#Ghost.png#Hellbat.png#Hellion.png#Liberator.png#Marauder.png#Marine.png#Medivac.png#MULE.png#Point_defense_drone.png#Raven.png#Reaper.png#SCV.png#SiegeTank.png#Thor.png#Viking.png#WidowMine.png',
-            'zerg_buildings':
-                'Baneling_Nest.png#Creep_Tumor.png#Evolution_Chamber.png#Extractor.png#Greater_Spire.png#Hatchery.png#Hive.png#Hydralisk_Den.png#Infestation_Pit.png#Lair.png#LurkerDen.png#Nydus_Network.png#Nydus_Worm.png#Roach_Warren.png#Spawning_Pool.png#Spine_Crawler.png#Spire.png#Spore_Crawler.png#Ultralisk_Cavern.png',
-            'zerg_techs':
-                'Adaptive_Talons.png#Adrenal_glands.png#Anabolic_Synthesis.png#Burrow.png#Centrifugal_hooks.png#Chitinous_Plating.png#Flyer_attack_1.png#Flyer_attack_2.png#Flyer_attack_3.png#Flyer_carapace_1.png#Flyer_carapace_2.png#Flyer_carapace_3.png#Glial_reconstitution.png#Grooved_Spines.png#Ground_carapace_1.png#Ground_carapace_2.png#Ground_carapace_3.png#Melee_attacks_1.png#Melee_attacks_2.png#Melee_attacks_3.png#Metabolic_boost.png#Microbial_Shroud.png#Missile_attacks_1.png#Missile_attacks_2.png#Missile_attacks_3.png#Muscular_Augments.png#Mutate_Ventral_Sacs.png#Neural_parasite.png#Pathogen_glands.png#Pneumatized_carapace.png#Seismic_Spines.png#Tunneling_claws.png',
-            'zerg_units':
-                'Baneling.png#Broodling.png#Brood_Lord.png#Changeling.png#Corruptor.png#Drone.png#Hydralisk.png#Infested_Terran.png#Infestor.png#Larva.png#Lurker.png#Mutalisk.png#Overlord.png#Overseer.png#Queen.png#Ravager.png#Roach.png#Swarm_Host.png#Ultralisk.png#Viper.png#Zergling.png'
-          };
+    imagesDict =
+    {
+      'protoss_buildings':
+        'Assimilator.png#Cybernetics_Core.png#Dark_Shrine.png#Fleet_Beacon.png#Forge.png#Gateway.png#Nexus.png#Photon_Cannon.png#Pylon.png#Robotics_Bay.png#Robotics_Facility.png#ShieldBattery.png#Stargate.png#StasisWard.png#Templar_Archives.png#Twilight_Council.png#Warp_Gate.png',
+      'protoss_techs':
+        'Air_armor_1.png#Air_armor_2.png#Air_armor_3.png#Air_weapons_1.png#Air_weapons_2.png#Air_weapons_3.png#Anion_Pulse-Crystals.png#Battery_Overcharge.png#Blink.png#Charge.png#Chrono_boost.png#Extended_thermal_lances.png#Flux_Vanes.png#Gravitic_booster.png#Gravitic_drive.png#Graviton_catapult.png#Ground_armor_1.png#Ground_armor_2.png#Ground_armor_3.png#Ground_weapons_1.png#Ground_weapons_2.png#Ground_weapons_3.png#Guardian_shield.png#Mass_Recall.png#Psionic_storm.png#Resonating_Glaives.png#Shadow_Stride.png#Shields_1.png#Shields_2.png#Shields_3.png#Tectonic_Destabilizers.png#Transform_warpgate.png',
+      'protoss_units':
+        'Adept.png#Archon.png#Carrier.png#Colossus.png#Dark_Templar.png#Disruptor.png#High_Templar.png#Immortal.png#Mothership.png#Mothership_Core.png#Observer.png#Oracle.png#Phoenix.png#Probe.png#Sentry.png#Stalker.png#Tempest.png#VoidRay.png#Warp_Prism.png#Zealot.png',
+      'race_icon':
+        'AnyRaceIcon.png#ProtossIcon.png#TerranIcon.png#ZergIcon.png',
+      'resource': 'minerals.png#vespene_gas.png',
+      'terran_buildings':
+        'Armory.png#Barracks.png#Bunker.png#CommandCenter.png#EngineeringBay.png#Factory.png#FusionCore.png#GhostAcademy.png#MissileTurret.png#OrbitalCommand.png#PlanetaryFortress.png#Reactor.png#Refinery.png#SensorTower.png#Starport.png#SupplyDepot.png#TechLab.png',
+      'terran_techs':
+        'Advanced_Ballistics.png#Behemoth_reactor.png#Building_armor.png#Build_Reactor.png#Build_Tech_Lab.png#Calldown_extra_supplies.png#Calldown_mule.png#Cloak.png#Enhanced_Shockwaves.png#High_Capacity_Fuel_Tanks.png#Hisec_auto_tracking.png#Infantry_armor_1.png#Infantry_armor_2.png#Infantry_armor_3.png#Infantry_weapons_1.png#Infantry_weapons_2.png#Infantry_weapons_3.png#Lower.png#Moebius_reactor.png#Neosteel_frames.png#Nuke.png#Scanner_sweep.png#Ship_weapons_1.png#Ship_weapons_2.png#Ship_weapons_3.png#Vehicle_plating_1.png#Vehicle_plating_2.png#Vehicle_plating_3.png#Vehicle_weapons_1.png#Vehicle_weapons_2.png#Vehicle_weapons_3.png#Yamato_cannon.png',
+      'terran_units':
+        'Auto-turret.png#Banshee.png#Battlecruiser.png#Cyclone.png#Ghost.png#Hellbat.png#Hellion.png#Liberator.png#Marauder.png#Marine.png#Medivac.png#MULE.png#Point_defense_drone.png#Raven.png#Reaper.png#SCV.png#SiegeTank.png#Thor.png#Viking.png#WidowMine.png',
+      'zerg_buildings':
+        'Baneling_Nest.png#Creep_Tumor.png#Evolution_Chamber.png#Extractor.png#Greater_Spire.png#Hatchery.png#Hive.png#Hydralisk_Den.png#Infestation_Pit.png#Lair.png#LurkerDen.png#Nydus_Network.png#Nydus_Worm.png#Roach_Warren.png#Spawning_Pool.png#Spine_Crawler.png#Spire.png#Spore_Crawler.png#Ultralisk_Cavern.png',
+      'zerg_techs':
+        'Adaptive_Talons.png#Adrenal_glands.png#Anabolic_Synthesis.png#Burrow.png#Centrifugal_hooks.png#Chitinous_Plating.png#Flyer_attack_1.png#Flyer_attack_2.png#Flyer_attack_3.png#Flyer_carapace_1.png#Flyer_carapace_2.png#Flyer_carapace_3.png#Glial_reconstitution.png#Grooved_Spines.png#Ground_carapace_1.png#Ground_carapace_2.png#Ground_carapace_3.png#Melee_attacks_1.png#Melee_attacks_2.png#Melee_attacks_3.png#Metabolic_boost.png#Microbial_Shroud.png#Missile_attacks_1.png#Missile_attacks_2.png#Missile_attacks_3.png#Muscular_Augments.png#Mutate_Ventral_Sacs.png#Neural_parasite.png#Pathogen_glands.png#Pneumatized_carapace.png#Seismic_Spines.png#Tunneling_claws.png',
+      'zerg_units':
+        'Baneling.png#Broodling.png#Brood_Lord.png#Changeling.png#Corruptor.png#Drone.png#Hydralisk.png#Infested_Terran.png#Infestor.png#Larva.png#Lurker.png#Mutalisk.png#Overlord.png#Overseer.png#Queen.png#Ravager.png#Roach.png#Swarm_Host.png#Ultralisk.png#Viper.png#Zergling.png'
+    };
 
   // Split each string (e.g. 'image_0#image_1#image_2') in a list of images.
   for (const [key, value] of Object.entries(imagesDict)) {


### PR DESCRIPTION
Adding `?gameId=aoe4` at the end of the url will open the overlay with AoE4 instead of the default AoE2 (works also with the other games: `aoe2`, `aom` and `sc2`).

On top of that, aoe4guides.com BOs can be directly fetched by adding the following code to the URL: `?gameId=aoe4&buildOrderId=aoe4guides|BO_ID`, where `BO_ID` is available at the end of the url page on aoe4guides (e.g. https://aoe4guides.com/builds/TUl77gWBVBqtsY8yNuMe can be fetched using `?gameId=aoe4&buildOrderId=aoe4guides|TUl77gWBVBqtsY8yNuMe`).

A few corrections on the single panel feature (Open full page) are also added.