### PR TITLE
Solve persistent spinner

### DIFF
--- a/docs/rts_overlay.js
+++ b/docs/rts_overlay.js
@@ -4711,7 +4711,9 @@ function openSinglePanelPageFromDescription(columnsDescription, sectionsHeader =
   htmlContent += '</body>\n\n</html>';
 
   // Update overlay HTML content
+  fullPageWindow.document.open();
   fullPageWindow.document.write(htmlContent);
+  fullPageWindow.document.close();
 }
 
 /**
@@ -4823,7 +4825,9 @@ function displayOverlay() {
   }
 
   // Update overlay HTML content
+  overlayWindow.document.open();
   overlayWindow.document.write(htmlContent);
+  overlayWindow.document.close();
 }
 
 /**


### PR DESCRIPTION
Before, when a new tab was opened (for example when using the "open full page" button), the document wasn't written correctly and so the loading spinner remained after the tab finished loading. This fixes that.